### PR TITLE
feat: omnibox suffix

### DIFF
--- a/packages/pds-storybook/stories/components/PdsOmnibox.stories.js
+++ b/packages/pds-storybook/stories/components/PdsOmnibox.stories.js
@@ -533,3 +533,16 @@ export const CombinedCategories = {
     },
   },
 };
+
+export const SuffixIcon = {
+  render: () => html`
+    <div>
+      <pds-omnibox
+        name="suffix1"
+      >
+        <pds-icon icon="star" slot="suffix"></pds-icon>
+      </pds-omnibox>
+    </div>
+  `,
+};
+

--- a/public/assets/pds/components/pds-omnibox.js
+++ b/public/assets/pds/components/pds-omnibox.js
@@ -49,6 +49,7 @@ export class PdsOmnibox extends HTMLElement {
 
   constructor() {
     super();
+
     this.#root = this.attachShadow({ mode: "open" });
     this.#internals = this.attachInternals();
     this.#renderStructure();
@@ -67,6 +68,10 @@ export class PdsOmnibox extends HTMLElement {
         "suggestions-updated",
         this.#suggestionsUpdatedHandler,
       );
+    }
+
+    if (this.#hasSuffix) {
+      this.#input?.parentElement.classList.add('has-suffix');
     }
   }
 
@@ -200,6 +205,7 @@ export class PdsOmnibox extends HTMLElement {
   #renderStructure() {
     this.#root.innerHTML = `
 			<div class="ac-container input-icon">
+				<slot name="suffix"></slot>
 				<pds-icon morph icon="${DEFAULT_ICON}"></pds-icon>
 				<input class="ac-input" type="search" placeholder="${DEFAULT_PLACEHOLDER}" autocomplete="off" />
 			</div>
@@ -259,6 +265,12 @@ export class PdsOmnibox extends HTMLElement {
 				.ac-container {
 					position: relative;
 					width: 100%;
+
+					&.has-suffix {
+						.ac-input {
+							padding-right: calc(var(--icon-size-md) + var(--spacing-6));
+						}
+					}
 
 					.ac-input {
 						width: 100%;
@@ -338,7 +350,6 @@ export class PdsOmnibox extends HTMLElement {
 							}
 
 							.category {
-								
 								color: var(--ac-color, var(--ac-color-muted));
 							}
 
@@ -376,6 +387,11 @@ export class PdsOmnibox extends HTMLElement {
 							white-space: unset;
 							height: auto !important;
 						}
+					}
+
+					slot[name="suffix"]::slotted(*) {
+						position: absolute;
+						right: var(--spacing-3);
 					}
 
 					&.ac-active[data-direction="down"] {
@@ -797,6 +813,10 @@ export class PdsOmnibox extends HTMLElement {
 
   #resetIconToDefault() {
     this.#icon?.setAttribute("icon", this.icon);
+  }
+
+  get #hasSuffix() {
+    return !!this.#root.querySelector('slot[name="suffix"]')?.assignedElements?.()?.length;
   }
 }
 


### PR DESCRIPTION
This PR adds a `suffix` slot to omnibox.
I'd like to be able to add stuff at the end of omnibox - like this wonderful `star` icon:

<img width="886" height="101" alt="Screenshot 2026-02-16 at 17 05 56" src="https://github.com/user-attachments/assets/19715005-5b10-4dd4-a965-5780414e7246" />
