### PR TITLE
Fix: icon rotation to center around the icon's own center using viewBox

### DIFF
--- a/public/assets/pds/components/pds-icon.js
+++ b/public/assets/pds/components/pds-icon.js
@@ -347,7 +347,7 @@ export class SvgIcon extends HTMLElement {
     // always around the icon's own centre regardless of coordinate space.
     const buildTransform = (rot, viewBox) => {
       if (rot === "0") return "";
-      const parts = (viewBox || "0 0 256 256").split(/[\s,]+/).map(Number);
+      const parts = (viewBox || "0 0 256 256").trim().split(/[\s,]+/).map(Number);
       if (parts.length === 4 && parts.every(Number.isFinite)) {
         const cx = parts[0] + parts[2] / 2;
         const cy = parts[1] + parts[3] / 2;

--- a/public/assets/pds/components/pds-icon.js
+++ b/public/assets/pds/components/pds-icon.js
@@ -343,8 +343,18 @@ export class SvgIcon extends HTMLElement {
       this.removeAttribute("data-icon-not-found");
     }
 
-    // Build transform string for rotation
-    const transform = rotate !== "0" ? `rotate(${rotate} 128 128)` : "";
+    // Build transform string for rotation, using viewBox center so rotation is
+    // always around the icon's own centre regardless of coordinate space.
+    const buildTransform = (rot, viewBox) => {
+      if (rot === "0") return "";
+      const parts = (viewBox || "0 0 256 256").split(/[\s,]+/).map(Number);
+      if (parts.length === 4 && parts.every(Number.isFinite)) {
+        const cx = parts[0] + parts[2] / 2;
+        const cy = parts[1] + parts[3] / 2;
+        return `rotate(${rot} ${cx} ${cy})`;
+      }
+      return `rotate(${rot} 128 128)`;
+    };
     const defaultViewBox = "0 0 256 256";
 
     const resolveIconData = (iconName) => {
@@ -529,9 +539,9 @@ export class SvgIcon extends HTMLElement {
 
     this._svgOldEl.setAttribute("aria-hidden", "true");
 
-    this._iconOldGroupEl.setAttribute("transform", transform);
+    this._iconOldGroupEl.setAttribute("transform", buildTransform(rotate, currentData.viewBox));
     this._iconOldGroupEl.innerHTML = currentData.symbolMarkup;
-    this._iconNewGroupEl.setAttribute("transform", transform);
+    this._iconNewGroupEl.setAttribute("transform", buildTransform(rotate, nextData.viewBox));
     this._iconNewGroupEl.innerHTML = nextData.symbolMarkup;
   }
 


### PR DESCRIPTION
## Summary

I  wanted to fix the rotation so it rotates around the center of the SVG's viewBox, not hardcoded 128 128 (which only works for 0 0 256 256). I need to calculate the center from the actual viewBox values.

The viewBox format is "x y width height", so the center would be:

centerX = x + width/2
centerY = y + height/2
For the default "0 0 256 256": centerX = 0 + 256/2 = 128, centerY = 0 + 256/2 = 128 ✓

I need to find where the transform is built and update it to use the actual viewBox center.

The transform is currently hardcoded with 128 128 before we even know what viewBox we're working with. Since resolveIconData is called separately for each icon and could return different viewBoxes, I need to compute the center after getting the viewBox data, then apply the transform to the appropriate group elements using that calculated center.

I'll create a helper function that extracts the viewBox dimensions and calculates the correct center point, then use it to build the transform for each icon individually.

I see the transform isn't actually needed in resolveIconData, so I can focus on the specific lines that need changing. Looking at the current implementation around line 348, I need to replace the static transform calculation with a function that computes separate transforms for each icon based on their viewBox, then update both setAttribute calls accordingly.

## Changes

The `buildTransform` helper now parses the actual viewBox (`x y width height`) and computes the center as `(x + width/2, y + height/2)`. Each layer (`layer-old` / `layer-new`) gets its own transform derived from its own viewBox, so rotation always pivots around the icon's actual center regardless of coordinate space.