### PR TITLE
Add part attributes to PDS icons for improved styling and accessib…

### DIFF
--- a/public/assets/pds/components/pds-icon.js
+++ b/public/assets/pds/components/pds-icon.js
@@ -618,12 +618,12 @@ export class SvgIcon extends HTMLElement {
           justify-content: center;
         }
       </style>
-      <span class="icon-stack">
-        <svg class="pds-icon layer-old" aria-hidden="true">
-          <g id="icon-group-old"></g>
+      <span class="icon-stack" part="stack">
+        <svg class="pds-icon layer-old" aria-hidden="true" part="icon-old">
+          <g id="icon-group-old" part="group-old"></g>
         </svg>
-        <svg class="pds-icon layer-new" aria-hidden="true">
-          <g id="icon-group-new"></g>
+        <svg class="pds-icon layer-new" aria-hidden="true" part="icon-new">
+          <g id="icon-group-new" part="group-new"></g>
         </svg>
       </span>
       <slot name="fallback"></slot>


### PR DESCRIPTION
…ility

## Summary

add shadow part names to the two SVG layers and their inner <g> groups 

Explain what this PR does and why.

## Changes

Added the approved part names in [pds-icon.js]

stack on the wrapper span
icon-old on the old SVG layer
icon-new on the new SVG layer
group-old on the old g node
group-new on the new g node

## Checklist
- [ ] Builds locally (`npm run build`)
- [ ] Tests or examples updated (if applicable)
- [ ] Docs updated (README/GETTING-STARTED) if behavior changed
- [ ] Linked issue (if any): Closes #
