### PR TITLE
Fix URL hash parsing to handle edge cases in tab synchronization

### DIFF
--- a/public/assets/pds/components/pds-tabstrip.js
+++ b/public/assets/pds/components/pds-tabstrip.js
@@ -182,7 +182,7 @@ class TabStrip extends HTMLElement {
 
   #syncFromUrl(initial = false) {
     if (!this.#panels.length) return;
-    const hashId = (location.hash || "").slice(1);
+    const [hashId = ""] = location.hash.slice(1).split(/([/?&#].*)/);
     const exists = this.#panels.some((p) => p.id === hashId);
     const next = exists
       ? hashId


### PR DESCRIPTION
## Summary

in case the url ends with #hashID?foo=true or something similar` hashId = (location.hash || "").slice(1) `will be looking for an hashId that cannot be found, so hashId should take all legit characters from # till invalid character

## Changes

The split(/([/?&#].*)/) regex splits at the first ?, /, &, or # character, so a hash like #tabId?foo=true or #tabId&bar=1 correctly yields just tabId as hashId. The (location.hash || "") guard was also redundant since String.slice on an empty string is safe.

## Checklist
- [ ] Builds locally (`npm run build`)
- [ ] Tests or examples updated (if applicable)
- [ ] Docs updated (README/GETTING-STARTED) if behavior changed
- [ ] Linked issue (if any): Closes #
