### PR TITLE
pds-omnibox-exportparts

### DIFF
--- a/public/assets/pds/components/pds-omnibox.js
+++ b/public/assets/pds/components/pds-omnibox.js
@@ -22,6 +22,10 @@
  * @element pds-omnibox
  * @formAssociated
  *
+ * @csspart input - The search input element
+ * @csspart suggestions - The autocomplete results container (added dynamically by AutoComplete)
+ * @csspart item - Each individual autocomplete result row (added dynamically by AutoComplete)
+ *
  * @attr {string} name - Form field name for submitted data
  * @attr {string} placeholder - Placeholder text for the search input
  * @attr {string} value - Current input value

--- a/public/assets/pds/components/pds-tags.js
+++ b/public/assets/pds/components/pds-tags.js
@@ -313,7 +313,7 @@ class PdsTags extends HTMLElement {
 			<div class="stack-sm" part="wrap">
 				<div class="chips" part="chips" aria-live="polite"></div>
 				<span class="empty" part="empty">${msg("No tags selected.")}</span>
-				<pds-omnibox part="omnibox"></pds-omnibox>
+				<pds-omnibox part="omnibox" exportparts="input, suggestions, item"></pds-omnibox>
 			</div>
 		`;
 


### PR DESCRIPTION
## Summary

pds-autocomplete (not a web component) appends its resultsDiv directly into pds-omnibox's shadow DOM, so part="suggestions" and part="item" are already native shadow parts of pds-omnibox — no code change needed there.
pds-tags embeds <pds-omnibox> but doesn't forward its shadow parts outward. We need to add exportparts to that element.

## Changes

pds-tags.js: add exportparts="input, suggestions, item" to the <pds-omnibox> element in #render()
pds-omnibox.js: add @csspart JSDoc entries for input, suggestions, and item so the API is documented

