### PR TITLE
Fix localization shared state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,5 @@ jobs:
       - name: Build
         run: npm run build
 
-      # Uncomment if tests are added later
-      # - name: Test
-      #   run: npm test
+      - name: Test
+        run: npm test

--- a/esbuild-dev.js
+++ b/esbuild-dev.js
@@ -44,6 +44,10 @@ const copyManagerToCorePlugin = {
         const enhancersDest = path.join(coreDir, "pds-enhancers.js");
         await copyFile(enhancersSrc, enhancersDest);
 
+        const localizationSrc = path.join(process.cwd(), "public", "assets", "js", "pds-localization.js");
+        const localizationDest = path.join(coreDir, "pds-localization.js");
+        await copyFile(localizationSrc, localizationDest);
+
       } catch (err) {
         console.warn("[pds] Failed to copy PDS runtime assets to public/assets/pds:", err.message);
       }
@@ -52,7 +56,11 @@ const copyManagerToCorePlugin = {
 };
 
 const config = {
-  entryPoints: ["src/js/lit.js", "src/js/app.js", "src/js/pds.js", "src/js/pds-manager.js", "src/js/pds-autocomplete.js", "src/js/pds-ask.js", "src/js/pds-toast.js", "src/js/pds-enhancers.js"],
+  // Must match esbuild-build.js. Omitting src/js/pds-localization.js here meant
+  // `npm run dev` served the stale committed public/assets/pds/core copy, so a
+  // freshly built pds-enhancers.js ran against a different localization runtime
+  // than the one receiving configureLocalization().
+  entryPoints: ["src/js/lit.js", "src/js/app.js", "src/js/pds.js", "src/js/pds-manager.js", "src/js/pds-autocomplete.js", "src/js/pds-ask.js", "src/js/pds-toast.js", "src/js/pds-enhancers.js", "src/js/pds-localization.js"],
   plugins: [rebuildNotifyPlugin(), copyManagerToCorePlugin],
   platform: "browser", 
   target: "es2022", 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   ],
   "scripts": {
     "dev": "node esbuild-dev.js",
+    "test": "node --test src/js/common/localization-resource-provider.test.mjs src/js/common/localization.shared-state.test.mjs",
     "prebuild": "npm run types",
     "build": "node esbuild-build.js",
     "types": "tsc -p tsconfig.json && node scripts/sync-types.mjs",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "src/js/pds.js",
     "src/js/pds-singleton.js",
     "src/js/common/",
+    "!src/js/**/*.test.mjs",
     "src/js/pds-live-manager/",
     "src/js/pds-core/",
     "custom-elements.json",

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -2,19 +2,111 @@ import { pdsLog } from "./pds-log.js";
 
 const __DEFAULT_LOCALE__ = "en";
 
-const __localizationState = {
-  defaultLocale: __DEFAULT_LOCALE__,
-  provider: null,
-  messagesByLocale: new Map(),
-  loadingByLocale: new Map(),
-  observer: null,
-  reconcileTimer: null,
-  requestedKeys: new Set(),
-  textNodeKeyMap: new WeakMap(),
-  attributeKeyMap: new WeakMap(),
-  valueToKeys: new Map(),
-  missingWarnings: new Set(),
-};
+/**
+ * Key under which the one true localization state lives on the global scope.
+ *
+ * The string is duplicated rather than imported, matching how `pds-log.js`
+ * reaches `__PURE_DS_PDS_SINGLETON__`: modules under `common/` are leaf
+ * utilities and must not depend on `pds-singleton.js`. Importing it would also
+ * give `import "@pure-ds/core/localization"` the side effect of instantiating
+ * the PDS singleton, and would make this bundle -- which is loaded dynamically
+ * and may evaluate before, after, or entirely without `pds.js` -- depend on
+ * load order.
+ */
+const __LOCALIZATION_STATE_KEY = "__PURE_DS_LOCALIZATION_STATE__";
+
+function __createLocalizationState() {
+  return {
+    defaultLocale: __DEFAULT_LOCALE__,
+    provider: null,
+    messagesByLocale: new Map(),
+    loadingByLocale: new Map(),
+    observer: null,
+    reconcileTimer: null,
+    requestedKeys: new Set(),
+    textNodeKeyMap: new WeakMap(),
+    attributeKeyMap: new WeakMap(),
+    valueToKeys: new Map(),
+    missingWarnings: new Set(),
+    configureCount: 0,
+  };
+}
+
+/**
+ * Backfill fields an older copy of this module may not have created.
+ *
+ * Must test with `in`, never `||=` or `??=`: `provider`, `observer` and
+ * `reconcileTimer` are legitimately falsy, so a truthiness test would clobber
+ * live values -- including, once the reconciler serializes its passes, the
+ * in-flight latch that makes concurrent copies safe.
+ */
+function __adoptLocalizationState(existingState) {
+  const defaults = __createLocalizationState();
+  for (const field of Object.keys(defaults)) {
+    if (!(field in existingState)) {
+      existingState[field] = defaults[field];
+    }
+  }
+  return existingState;
+}
+
+function __resolveGlobalScope() {
+  try {
+    if (typeof globalThis !== "undefined") return globalThis;
+    if (typeof window !== "undefined") return window;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Resolve the single source of truth for localization state, shared by every
+ * copy of this module in the realm.
+ *
+ * Several `@pure-ds/core` bundles statically inline this file
+ * (`pds-localization.js`, `pds-enhancers.js`, `pds-manager.js`) and a consumer
+ * may bundle a further copy, so module-level state would fork: only the copy
+ * that receives `configureLocalization()` would work, and every `msg()` call in
+ * the others would return its raw key. Two configured copies would run two
+ * MutationObservers over one document, each seeing the other's writes as
+ * external mutations.
+ *
+ * INVARIANT: the state OBJECT identity is never replaced -- only its fields are
+ * mutated. Every access in this file goes through `__localizationState.<field>`,
+ * so a field reassignment (as `configureLocalization` does for the key maps) is
+ * immediately visible to all copies. Never reassign `__localizationState`, and
+ * never destructure a field into a module-level binding: either re-forks the
+ * state silently.
+ *
+ * Fields are append-only, because the object is a contract across versions. If
+ * a breaking shape change is ever needed, change the KEY rather than the shape
+ * -- refusing to adopt an older-shaped state would recreate the fork this
+ * exists to remove.
+ */
+function __resolveLocalizationState() {
+  const scope = __resolveGlobalScope();
+  if (!scope) {
+    return __createLocalizationState();
+  }
+
+  const existingState = scope[__LOCALIZATION_STATE_KEY];
+  if (existingState && typeof existingState === "object") {
+    return __adoptLocalizationState(existingState);
+  }
+
+  const createdState = __createLocalizationState();
+  try {
+    scope[__LOCALIZATION_STATE_KEY] = createdState;
+  } catch {
+    // Frozen or sealed global (hardened realms, some CSP shims): degrade to
+    // per-copy state, which is the pre-fix behaviour. Never throw from module
+    // evaluation.
+  }
+  return createdState;
+}
+
+const __localizationState = __resolveLocalizationState();
 
 const __LOCALIZABLE_ATTRIBUTES = [
   "title",
@@ -780,9 +872,12 @@ function __attachLangObserver() {
     return;
   }
 
+  // Exactly one observer must exist per realm, however many copies of this
+  // module are loaded. Re-creating it on every configure would swap a working
+  // observer for an identical one and open a window in which mutations are
+  // missed, so an already-attached observer is left alone.
   if (__localizationState.observer) {
-    __localizationState.observer.disconnect();
-    __localizationState.observer = null;
+    return;
   }
 
   if (typeof MutationObserver !== "function") {
@@ -802,6 +897,13 @@ function __attachLangObserver() {
   });
 
   __localizationState.observer = observer;
+}
+
+function __detachLangObserver() {
+  if (__localizationState.observer) {
+    __localizationState.observer.disconnect();
+    __localizationState.observer = null;
+  }
 }
 
 function __resolveTranslation(key, values = [], options = {}, template = null) {
@@ -887,10 +989,29 @@ export function getLocalizationState() {
 }
 
 export function configureLocalization(config = null) {
-  if (__localizationState.observer) {
-    __localizationState.observer.disconnect();
-    __localizationState.observer = null;
+  // The state is shared across every copy of this module in the realm, so a
+  // second call tears down the first caller's configuration. That is the
+  // documented contract, but it is also the likeliest cause of a "my provider
+  // disappeared" report, so make it visible.
+  __localizationState.configureCount += 1;
+  if (__localizationState.configureCount > 1) {
+    const incomingLocale =
+      typeof config?.locale === "string" && config.locale.trim()
+        ? config.locale
+        : __DEFAULT_LOCALE__;
+    pdsLog(
+      "debug",
+      `[i18n] configureLocalization() call #${__localizationState.configureCount} replaces the previous configuration (incoming locale "${incomingLocale}"${
+        config ? "" : ", resetting to defaults"
+      }).`
+    );
   }
+
+  // The observer is deliberately NOT disconnected here. It is realm-wide and
+  // idempotent (see __attachLangObserver), and it observes only `lang` plus
+  // structure -- nothing that the configuration changes. MutationObserver
+  // callbacks are microtasks and reconcile is a macrotask, so neither can
+  // interleave with this synchronous reset.
   if (__localizationState.reconcileTimer) {
     clearTimeout(__localizationState.reconcileTimer);
     __localizationState.reconcileTimer = null;
@@ -907,6 +1028,11 @@ export function configureLocalization(config = null) {
   __localizationState.missingWarnings.clear();
 
   if (!config || typeof config !== "object") {
+    // A reset leaves nothing to reconcile for, and this path never reaches
+    // __attachLangObserver, so the observer must be torn down here or it would
+    // keep running a document-wide "[lang]" query on every mutation batch for
+    // the rest of the page's life.
+    __detachLangObserver();
     return getLocalizationState();
   }
 

--- a/src/js/common/localization.shared-state.test.mjs
+++ b/src/js/common/localization.shared-state.test.mjs
@@ -1,0 +1,204 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Several @pure-ds/core bundles statically inline common/localization.js, and a
+ * consumer may bundle a further copy, so these tests load the module more than
+ * once and assert that the copies share one state object.
+ *
+ * ISOLATION CAVEAT: a copy captures the state object once, at import time
+ * (`const __localizationState = __resolveLocalizationState()`). Deleting
+ * globalThis[STATE_KEY] afterwards does NOT detach an already-loaded copy. So
+ * every test must reset the global BEFORE loading its copies, and no copy may
+ * ever be shared between tests -- hence the monotonic counter, which guarantees
+ * a distinct specifier and therefore a distinct module instance.
+ *
+ * No DOM is needed: every DOM touch in the module under test is guarded by a
+ * `typeof document === "undefined"` / `typeof window === "undefined"` check.
+ */
+const STATE_KEY = "__PURE_DS_LOCALIZATION_STATE__";
+const MODULE_URL = new URL("./localization.js", import.meta.url).href;
+
+let __copyCounter = 0;
+
+function loadCopy() {
+  __copyCounter += 1;
+  return import(`${MODULE_URL}?copy=${__copyCounter}`);
+}
+
+function resetSharedState() {
+  delete globalThis[STATE_KEY];
+}
+
+test("two loaded copies of the localization module are genuinely distinct instances", async () => {
+  resetSharedState();
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    // Guards every other test in this file: if the cache-busted import ever
+    // stops producing separate module instances, the sharing assertions below
+    // would pass trivially without testing anything.
+    assert.notStrictEqual(copyA.msg, copyB.msg);
+    assert.notStrictEqual(copyA.configureLocalization, copyB.configureLocalization);
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("configuring one copy configures every copy", async () => {
+  resetSharedState();
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    copyA.configureLocalization({
+      locale: "nl",
+      messages: { Hello: "Hallo" },
+    });
+
+    // Before the shared-state fix copy B kept its own state: "Hello" / "en".
+    assert.equal(copyB.msg("Hello"), "Hallo");
+    assert.equal(copyB.getLocalizationState().locale, "nl");
+    assert.deepEqual(copyB.getLocalizationState().loadedLocales, ["nl"]);
+    assert.equal(copyB.getLocalizationState().hasProvider, false);
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("a key requested through one copy is registered for every copy", async () => {
+  resetSharedState();
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    copyB.configureLocalization({
+      locale: "nl",
+      messages: { "Registered by A": "Door A geregistreerd" },
+    });
+
+    copyA.msg("Registered by A");
+
+    // White-box, because requestedKeys has no public getter -- this mirrors the
+    // heap-snapshot inspection that surfaced the bug. The registry is what the
+    // reconciler walks the DOM for, so a per-copy registry means msg() calls
+    // made inside pds-enhancers.js / pds-live.js are never localized.
+    const sharedState = globalThis[STATE_KEY];
+    assert.ok(sharedState, "expected the shared localization state to exist");
+    assert.ok(sharedState.requestedKeys.has("Registered by A"));
+
+    assert.equal(copyB.msg("Registered by A"), "Door A geregistreerd");
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("adopting an older-shaped state backfills missing fields without clobbering present ones", async () => {
+  resetSharedState();
+
+  try {
+    // An empty string is a legitimate value that is also falsy, so it only
+    // survives if the backfill tests with `in` rather than `||=` / `??=`.
+    globalThis[STATE_KEY] = { defaultLocale: "" };
+
+    const copy = await loadCopy();
+    const adoptedState = globalThis[STATE_KEY];
+
+    assert.equal(adoptedState.defaultLocale, "");
+    assert.equal(copy.getLocalizationState().locale, "");
+
+    assert.ok(adoptedState.messagesByLocale instanceof Map);
+    assert.ok(adoptedState.loadingByLocale instanceof Map);
+    assert.ok(adoptedState.requestedKeys instanceof Set);
+    assert.ok(adoptedState.missingWarnings instanceof Set);
+    assert.ok(adoptedState.valueToKeys instanceof Map);
+    assert.ok(adoptedState.textNodeKeyMap instanceof WeakMap);
+    assert.ok(adoptedState.attributeKeyMap instanceof WeakMap);
+    assert.equal(adoptedState.provider, null);
+    assert.equal(adoptedState.observer, null);
+    assert.equal(adoptedState.reconcileTimer, null);
+    assert.equal(adoptedState.configureCount, 0);
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("one observer is attached across copies, and a reset tears it down", async () => {
+  resetSharedState();
+
+  // Deliberately a stub, not a DOM shim: the assertions below are "how many
+  // observers were constructed" and "was disconnect() called", not anything
+  // about MutationObserver semantics. Record/replay behaviour of the observer
+  // itself is covered by the jsdom-based reconciler tests.
+  const observers = [];
+  const saved = {
+    window: globalThis.window,
+    document: globalThis.document,
+    MutationObserver: globalThis.MutationObserver,
+  };
+
+  globalThis.window = {};
+  globalThis.document = { documentElement: { getAttribute: () => null } };
+  globalThis.MutationObserver = class {
+    constructor() {
+      this.disconnected = false;
+      observers.push(this);
+    }
+    observe() {}
+    disconnect() {
+      this.disconnected = true;
+    }
+  };
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    copyA.configureLocalization({ locale: "nl", messages: { Hello: "Hallo" } });
+    assert.equal(observers.length, 1);
+
+    // A second configure through a different copy must not stack a second
+    // observer over the same document.
+    copyB.configureLocalization({ locale: "de", messages: { Hello: "Hallo" } });
+    assert.equal(observers.length, 1);
+    assert.equal(observers[0].disconnected, false);
+
+    // A reset has nothing left to reconcile for, so the observer must go --
+    // otherwise it keeps scheduling document-wide passes forever.
+    copyB.configureLocalization(null);
+    assert.equal(observers[0].disconnected, true);
+    assert.equal(globalThis[STATE_KEY].observer, null);
+  } finally {
+    globalThis.window = saved.window;
+    globalThis.document = saved.document;
+    globalThis.MutationObserver = saved.MutationObserver;
+    resetSharedState();
+  }
+});
+
+test("a global that rejects the write degrades to per-copy state instead of throwing", async () => {
+  resetSharedState();
+
+  // Hardened realms and some CSP shims make the global non-writable. Module
+  // evaluation must still succeed; falling back to per-copy state is the
+  // pre-fix behaviour, which is degraded but not broken.
+  Object.defineProperty(globalThis, STATE_KEY, {
+    value: 0,
+    writable: false,
+    configurable: true,
+  });
+
+  try {
+    const copy = await loadCopy();
+
+    assert.equal(globalThis[STATE_KEY], 0);
+    assert.equal(copy.msg("untranslated"), "untranslated");
+    assert.equal(copy.getLocalizationState().locale, "en");
+  } finally {
+    delete globalThis[STATE_KEY];
+  }
+});

--- a/src/js/common/msg.js
+++ b/src/js/common/msg.js
@@ -1,9 +1,0 @@
-export {
-  msg,
-  str,
-  joinStringsAndValues,
-  configureLocalization,
-  loadLocale,
-  setLocale,
-  getLocalizationState,
-} from "./localization.js";

--- a/src/js/pds.js
+++ b/src/js/pds.js
@@ -978,7 +978,12 @@ async function start(config) {
     if (localizationConfig) {
       await __loadLocalizationRuntime();
       configureLocalization(localizationConfig);
-    } else {
+    } else if (!__getLocalizationRuntimeSync()) {
+      // With no runtime loaded this usefully resets __fallbackLocalizationState
+      // and touches no shared state. With a runtime loaded it would forward to
+      // the real configureLocalization and tear down a working provider -- and
+      // since that state is realm-wide, every copy of the runtime on the page
+      // would lose its configuration at once.
       configureLocalization(null);
     }
 


### PR DESCRIPTION
## Summary

The stock reconciler in `@pure-ds/core@0.7.78` starves the browser main thread
and makes the app unresponsive in Chrome. From a DevTools allocation timeline it
accounted for **~52% of all heap allocation and ~56% of all allocation events**:

| Function | Alloc | Events |
| --- | --- | --- |
| `__localizeRequestedTextNodes` | 8.2 MB | 304,673 |
| `__localizeTextNode` | 7.4 MB | 270,892 |
| `__findRequestedKeyForText` | 3.7 MB | 178,657 |
| `__findRequestedSubsegmentForText` | 3.2 MB | 111,411 |
| `__localizeRequestedAttributes` | 2.5 MB | 107,358 |

Four compounding defects:

1. `__scheduleReconcile` cleared its debounce slot before running an `async`
   pass it never awaited, so passes stacked without bound.
2. The reconciler's own `nodeValue` writes were seen by its own
   `characterData` observer, retriggering it.
3. Every pass re-walked the whole DOM plus all 71 shadow roots and redid
   O(requestedKeys x locales) work per text node, even for unchanged nodes.
4. The translated-value index grew unboundedly, so passes got slower the
   longer a session ran.

Fixed by serializing passes, filtering self-inflicted mutations, adding a
value→key reverse index, skipping unchanged nodes, and capping the value index.
