### PR TITLE
Fix localization reconcile starvation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,5 @@ jobs:
       - name: Build
         run: npm run build
 
-      # Uncomment if tests are added later
-      # - name: Test
-      #   run: npm test
+      - name: Test
+        run: npm test

--- a/LOCALIZATION.md
+++ b/LOCALIZATION.md
@@ -119,6 +119,55 @@ This enables island behavior without special framework integration.
 
 This keeps runtime memory proportional to actively used languages.
 
+## Shared State Across Bundle Copies
+
+Localization state -- the provider, loaded bundles, requested keys, and the
+DOM observer -- lives on a single object shared by every copy of the
+localization runtime in a page, not per module instance. Several
+`@pure-ds/core` bundles (`core/pds-localization.js`, `core/pds-enhancers.js`,
+`core/pds-manager.js`) inline the same localization code, and a consumer's own
+app bundle may include a further copy; without sharing, only whichever copy
+received `configureLocalization()` would actually work, and every `msg()` call
+in the others would return its raw key.
+
+Consequences worth knowing:
+
+- A page cannot host two *independently configured* localization scopes --
+  the last `configureLocalization()` call wins, and a debug-level log records
+  when that happens more than once.
+- Exactly one `MutationObserver` runs per page, regardless of how many
+  bundle copies are loaded.
+- **All copies of `@pure-ds/core` in a page must be the same version, and at
+  least the version this was introduced in.** An older copy keeps private
+  state and does not participate in the shared runtime -- so a page that
+  mixes a stale cached bundle (e.g. from a CDN, a pinned `managerURL`, or an
+  un-synced web root) with a current one will see the older bug pattern for
+  that copy specifically.
+- Iframes and workers each have their own realm and their own `document`, so
+  they correctly get their own, independent localization state.
+
+## Reconciliation
+
+Localization writes to the DOM in **reconcile passes**, debounced 16ms after
+a `msg()` call registers a new key or the DOM mutates. A pass:
+
+- only re-examines a text node or attribute whose value has changed since it
+  was last visited (a locale bundle loading, a `lang` change, or a newly
+  registered key invalidates that cache);
+- ignores its own writes when deciding whether to schedule another pass, so
+  settling never costs an extra, wasted full-document walk;
+- runs at most 5 times in a row before yielding; if the DOM still hasn't
+  settled after 5 passes (for example, a `translate()` implementation that
+  keeps producing different output), PDS logs a warning and continues in the
+  next scheduling window rather than blocking indefinitely.
+
+`getLocalizationState()` includes `indexedValueCount`, the size of the
+internal value-to-key index used to recognize already-translated text. This
+index is capped (currently 1000 entries, FIFO eviction) so long sessions
+don't grow it without bound; exact-key matches are unaffected by eviction,
+but a very large, long-running page may occasionally miss recognizing an
+older *subsegment* match once its value has been evicted.
+
 ## Live Editor Language Selector
 
 In live mode (`liveEdit: true`), quick settings can show a **Language** selector.

--- a/esbuild-dev.js
+++ b/esbuild-dev.js
@@ -44,6 +44,10 @@ const copyManagerToCorePlugin = {
         const enhancersDest = path.join(coreDir, "pds-enhancers.js");
         await copyFile(enhancersSrc, enhancersDest);
 
+        const localizationSrc = path.join(process.cwd(), "public", "assets", "js", "pds-localization.js");
+        const localizationDest = path.join(coreDir, "pds-localization.js");
+        await copyFile(localizationSrc, localizationDest);
+
       } catch (err) {
         console.warn("[pds] Failed to copy PDS runtime assets to public/assets/pds:", err.message);
       }
@@ -52,7 +56,11 @@ const copyManagerToCorePlugin = {
 };
 
 const config = {
-  entryPoints: ["src/js/lit.js", "src/js/app.js", "src/js/pds.js", "src/js/pds-manager.js", "src/js/pds-autocomplete.js", "src/js/pds-ask.js", "src/js/pds-toast.js", "src/js/pds-enhancers.js"],
+  // Must match esbuild-build.js. Omitting src/js/pds-localization.js here meant
+  // `npm run dev` served the stale committed public/assets/pds/core copy, so a
+  // freshly built pds-enhancers.js ran against a different localization runtime
+  // than the one receiving configureLocalization().
+  entryPoints: ["src/js/lit.js", "src/js/app.js", "src/js/pds.js", "src/js/pds-manager.js", "src/js/pds-autocomplete.js", "src/js/pds-ask.js", "src/js/pds-toast.js", "src/js/pds-enhancers.js", "src/js/pds-localization.js"],
   plugins: [rebuildNotifyPlugin(), copyManagerToCorePlugin],
   platform: "browser", 
   target: "es2022", 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pure-ds/core",
-  "version": "0.7.30",
+  "version": "0.7.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pure-ds/core",
-      "version": "0.7.30",
+      "version": "0.7.81",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -31,8 +31,138 @@
         "@types/node": "^22.10.2",
         "esbuild": "^0.19.0",
         "fs-extra": "^11.1.1",
+        "jsdom": "^26.1.0",
         "typescript": "^5.6.3"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -564,6 +694,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -672,6 +812,20 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/custom-elements-manifest": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz",
@@ -679,10 +833,49 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
       "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
@@ -697,6 +890,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -879,6 +1085,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -935,6 +1195,53 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -986,6 +1293,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1010,6 +1324,13 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1018,6 +1339,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-type": {
@@ -1041,6 +1382,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pure-web": {
@@ -1098,6 +1449,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -1120,6 +1478,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -1145,6 +1523,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1156,6 +1561,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {
@@ -1202,6 +1633,106 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
       "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   ],
   "scripts": {
     "dev": "node esbuild-dev.js",
-    "test": "node --test src/js/common/localization-resource-provider.test.mjs src/js/common/localization.shared-state.test.mjs",
+    "test": "node --test src/js/common/localization-resource-provider.test.mjs src/js/common/localization.shared-state.test.mjs src/js/common/localization.test.mjs",
     "prebuild": "npm run types",
     "build": "node esbuild-build.js",
     "types": "tsc -p tsconfig.json && node scripts/sync-types.mjs",
@@ -124,6 +124,7 @@
     "@types/node": "^22.10.2",
     "esbuild": "^0.19.0",
     "fs-extra": "^11.1.1",
+    "jsdom": "^26.1.0",
     "typescript": "^5.6.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   ],
   "scripts": {
     "dev": "node esbuild-dev.js",
+    "test": "node --test src/js/common/localization-resource-provider.test.mjs src/js/common/localization.shared-state.test.mjs",
     "prebuild": "npm run types",
     "build": "node esbuild-build.js",
     "types": "tsc -p tsconfig.json && node scripts/sync-types.mjs",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "src/js/pds.js",
     "src/js/pds-singleton.js",
     "src/js/common/",
+    "!src/js/**/*.test.mjs",
     "src/js/pds-live-manager/",
     "src/js/pds-core/",
     "custom-elements.json",

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -27,6 +27,7 @@ function __createLocalizationState() {
     reconcileTimer: null,
     reconcileInFlight: false,
     reconcileDirty: false,
+    selfWrittenTextNodes: new WeakSet(),
     requestedKeys: new Set(),
     textNodeKeyMap: new WeakMap(),
     attributeKeyMap: new WeakMap(),
@@ -604,6 +605,23 @@ function __findRequestedSubsegmentForText(coreText) {
   return bestMatch;
 }
 
+/**
+ * Single write path for localized text. The characterData observer on
+ * document.documentElement sees every nodeValue assignment the reconciler
+ * makes, including its own, so a write recorded here is filtered back out in
+ * __attachLangObserver's callback instead of retriggering another pass.
+ *
+ * Added to the set only when a write actually happens -- an entry added on a
+ * no-op write would sit there and swallow the NEXT genuine external mutation
+ * to that node instead of this one.
+ */
+function __setTextNodeValue(textNode, nextValue) {
+  if (textNode.nodeValue !== nextValue) {
+    __localizationState.selfWrittenTextNodes.add(textNode);
+    textNode.nodeValue = nextValue;
+  }
+}
+
 async function __localizeTextNode(textNode) {
   if (!textNode || textNode.nodeType !== 3) {
     return;
@@ -648,9 +666,7 @@ async function __localizeTextNode(textNode) {
       core.slice(segmentMatch.end);
     const localizedText = `${leading}${localizedCore}${trailing}`;
 
-    if (localizedText !== textNode.nodeValue) {
-      textNode.nodeValue = localizedText;
-    }
+    __setTextNodeValue(textNode, localizedText);
     return;
   }
 
@@ -666,9 +682,7 @@ async function __localizeTextNode(textNode) {
     : translated;
   const nextText = `${leading}${translatedText}${trailing}`;
 
-  if (nextText !== textNode.nodeValue) {
-    textNode.nodeValue = nextText;
-  }
+  __setTextNodeValue(textNode, nextText);
 }
 
 async function __localizeRequestedTextNodes() {
@@ -930,8 +944,29 @@ function __attachLangObserver() {
     return;
   }
 
-  const observer = new MutationObserver(() => {
-    __scheduleReconcile();
+  const observer = new MutationObserver((records) => {
+    // A characterData record whose target is in selfWrittenTextNodes is the
+    // reconciler observing its own write. Consuming it here (rather than just
+    // checking it) is what stops that write from retriggering the very next
+    // pass -- without this the reconciler could livelock on any translation
+    // whose messages are not fixpoints (e.g. two keys translating to each
+    // other's source text). "attributes" (lang, per attributeFilter below)
+    // and "childList" records are never self-inflicted -- the reconciler only
+    // ever assigns nodeValue or setAttribute on existing nodes -- so they
+    // always count as external.
+    let externalMutation = false;
+    for (const record of records) {
+      if (record.type === "characterData") {
+        if (__localizationState.selfWrittenTextNodes.delete(record.target)) {
+          continue;
+        }
+      }
+      externalMutation = true;
+    }
+
+    if (externalMutation) {
+      __scheduleReconcile();
+    }
   });
 
   observer.observe(document.documentElement, {

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -1,6 +1,8 @@
 import { pdsLog } from "./pds-log.js";
 
 const __DEFAULT_LOCALE__ = "en";
+const __RECONCILE_DEBOUNCE_MS = 16;
+const __MAX_RECONCILE_PASSES = 5;
 
 /**
  * Key under which the one true localization state lives on the global scope.
@@ -23,6 +25,8 @@ function __createLocalizationState() {
     loadingByLocale: new Map(),
     observer: null,
     reconcileTimer: null,
+    reconcileInFlight: false,
+    reconcileDirty: false,
     requestedKeys: new Set(),
     textNodeKeyMap: new WeakMap(),
     attributeKeyMap: new WeakMap(),
@@ -852,8 +856,48 @@ async function __reconcileLocalization() {
   __pruneUndetectedLocales(detectedLocales);
 }
 
+/**
+ * Runs reconcile passes until the DOM settles or a cap is hit, serializing
+ * against `__scheduleReconcile` via `reconcileInFlight` so that mutations
+ * arriving mid-pass coalesce into `reconcileDirty` instead of starting a
+ * second concurrent pass. Without this latch, `__scheduleReconcile`'s
+ * un-awaited call to `__reconcileLocalization` let passes stack without
+ * bound under a busy MutationObserver.
+ */
+async function __runReconcilePasses() {
+  __localizationState.reconcileInFlight = true;
+  let passes = 0;
+
+  try {
+    do {
+      __localizationState.reconcileDirty = false;
+      passes += 1;
+      await __reconcileLocalization();
+    } while (__localizationState.reconcileDirty && passes < __MAX_RECONCILE_PASSES);
+  } finally {
+    __localizationState.reconcileInFlight = false;
+  }
+
+  // No work is dropped by the cap: a still-dirty state re-schedules for the
+  // next debounce window instead of settling silently, and there is no await
+  // between clearing the latch above and this check, so nothing else can run
+  // in between and observe a false "settled" state.
+  if (__localizationState.reconcileDirty) {
+    pdsLog(
+      "warn",
+      `[i18n] Localization did not settle after ${__MAX_RECONCILE_PASSES} reconcile passes; continuing in the next scheduling window.`
+    );
+    __scheduleReconcile();
+  }
+}
+
 function __scheduleReconcile() {
   if (typeof window === "undefined") {
+    return;
+  }
+
+  __localizationState.reconcileDirty = true;
+  if (__localizationState.reconcileInFlight) {
     return;
   }
 
@@ -863,8 +907,10 @@ function __scheduleReconcile() {
 
   __localizationState.reconcileTimer = setTimeout(() => {
     __localizationState.reconcileTimer = null;
-    __reconcileLocalization();
-  }, 16);
+    __runReconcilePasses().catch((error) => {
+      pdsLog("error", "[i18n] Localization reconcile pass failed.", error);
+    });
+  }, __RECONCILE_DEBOUNCE_MS);
 }
 
 function __attachLangObserver() {

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -28,6 +28,8 @@ function __createLocalizationState() {
     reconcileInFlight: false,
     reconcileDirty: false,
     selfWrittenTextNodes: new WeakSet(),
+    textNodeValueMap: new WeakMap(),
+    attributeValueMap: new WeakMap(),
     requestedKeys: new Set(),
     textNodeKeyMap: new WeakMap(),
     attributeKeyMap: new WeakMap(),
@@ -282,6 +284,18 @@ function __rebuildMessageValueIndex() {
   __localizationState.messageValueToKeys = index;
 }
 
+/**
+ * Wholesale-replaces the text/attribute skip caches. Called whenever the
+ * decision __localizeTextNode/__localizeAttribute made for a node could now
+ * be different even though the node's own value hasn't changed: a locale
+ * bundle arrived or changed, the effective locale scope changed (a `lang`
+ * mutation), or the default locale changed via setLocale().
+ */
+function __invalidateValueCaches() {
+  __localizationState.textNodeValueMap = new WeakMap();
+  __localizationState.attributeValueMap = new WeakMap();
+}
+
 function __setLocaleMessages(locale, messages) {
   const normalizedLocale = __resolveLocaleCandidate(locale);
   __localizationState.messagesByLocale.set(
@@ -289,12 +303,38 @@ function __setLocaleMessages(locale, messages) {
     __normalizeMessages(messages)
   );
   __rebuildMessageValueIndex();
+  __invalidateValueCaches();
+  // Loading a locale bundle can happen mid-pass, on demand, for a node the
+  // tree walker hasn't reached yet -- or, if two nodes share a locale scope
+  // that wasn't loaded yet, for a node that has already been processed and
+  // is otherwise done for this pass. Scheduling here (a no-op-to-dirty if a
+  // pass is already in flight) is what gives that earlier node another
+  // chance instead of leaving it permanently cached on a fallback value.
+  __scheduleReconcile();
 }
 
+/**
+ * Registers a key as one msg()/str() has asked for, returning whether it was
+ * newly added.
+ *
+ * A text node visited before its key was registered gets cached in
+ * textNodeValueMap as "nothing to do here" (see __localizeTextNode). Without
+ * invalidating on a genuinely new key, that cached decision would never be
+ * revisited, so server-rendered text whose key a later-mounted component
+ * registers via msg() would never localize.
+ */
 function __registerRequestedKey(key) {
-  if (typeof key === "string" && key.length > 0) {
-    __localizationState.requestedKeys.add(key);
+  if (typeof key !== "string" || key.length === 0) {
+    return false;
   }
+
+  if (__localizationState.requestedKeys.has(key)) {
+    return false;
+  }
+
+  __localizationState.requestedKeys.add(key);
+  __invalidateValueCaches();
+  return true;
 }
 
 function __indexTranslatedValue(key, value) {
@@ -689,6 +729,7 @@ function __setTextNodeValue(textNode, nextValue) {
     __localizationState.selfWrittenTextNodes.add(textNode);
     textNode.nodeValue = nextValue;
   }
+  __localizationState.textNodeValueMap.set(textNode, nextValue);
 }
 
 async function __localizeTextNode(textNode) {
@@ -701,8 +742,14 @@ async function __localizeTextNode(textNode) {
     return;
   }
 
-  const { leading, core, trailing } = __splitTextWhitespace(textNode.nodeValue);
+  const currentValue = textNode.nodeValue;
+  if (__localizationState.textNodeValueMap.get(textNode) === currentValue) {
+    return;
+  }
+
+  const { leading, core, trailing } = __splitTextWhitespace(currentValue);
   if (!core) {
+    __localizationState.textNodeValueMap.set(textNode, currentValue);
     return;
   }
 
@@ -714,6 +761,7 @@ async function __localizeTextNode(textNode) {
   if (!key) {
     const segmentMatch = __findRequestedSubsegmentForText(core);
     if (!segmentMatch) {
+      __localizationState.textNodeValueMap.set(textNode, currentValue);
       return;
     }
 
@@ -841,6 +889,28 @@ function __getElementAttributeKeyMap(element) {
   return map;
 }
 
+function __getElementAttributeValueMap(element) {
+  let map = __localizationState.attributeValueMap.get(element);
+  if (!map) {
+    map = new Map();
+    __localizationState.attributeValueMap.set(element, map);
+  }
+  return map;
+}
+
+/**
+ * Single write path for a localized attribute. No self-write filtering is
+ * needed here (unlike __setTextNodeValue): `lang` is not one of the
+ * localizable attributes, and the observer's attributeFilter is ["lang"], so
+ * a write here is structurally unobservable to it.
+ */
+function __setElementAttributeValue(element, attrName, nextValue) {
+  if (element.getAttribute(attrName) !== nextValue) {
+    element.setAttribute(attrName, nextValue);
+  }
+  __getElementAttributeValueMap(element).set(attrName, nextValue);
+}
+
 async function __localizeAttribute(element, attrName) {
   if (!element || typeof element.getAttribute !== "function") {
     return;
@@ -848,6 +918,11 @@ async function __localizeAttribute(element, attrName) {
 
   const rawValue = element.getAttribute(attrName);
   if (typeof rawValue !== "string" || !rawValue.length) {
+    return;
+  }
+
+  const valueMap = __getElementAttributeValueMap(element);
+  if (valueMap.get(attrName) === rawValue) {
     return;
   }
 
@@ -861,6 +936,7 @@ async function __localizeAttribute(element, attrName) {
   if (!key) {
     const segmentMatch = __findRequestedSubsegmentForText(rawValue);
     if (!segmentMatch) {
+      valueMap.set(attrName, rawValue);
       return;
     }
 
@@ -877,10 +953,7 @@ async function __localizeAttribute(element, attrName) {
       translatedText +
       rawValue.slice(segmentMatch.end);
 
-    if (localizedValue !== rawValue) {
-      element.setAttribute(attrName, localizedValue);
-    }
-
+    __setElementAttributeValue(element, attrName, localizedValue);
     keyMap.set(attrName, segmentMatch.key);
     return;
   }
@@ -896,9 +969,7 @@ async function __localizeAttribute(element, attrName) {
     ? __replacePlaceholders(translated, (index) => values[index])
     : translated;
 
-  if (translatedText !== rawValue) {
-    element.setAttribute(attrName, translatedText);
-  }
+  __setElementAttributeValue(element, attrName, translatedText);
 }
 
 async function __localizeRequestedAttributes(elements) {
@@ -1021,13 +1092,26 @@ function __attachLangObserver() {
     // ever assigns nodeValue or setAttribute on existing nodes -- so they
     // always count as external.
     let externalMutation = false;
+    let langMutated = false;
+
     for (const record of records) {
       if (record.type === "characterData") {
         if (__localizationState.selfWrittenTextNodes.delete(record.target)) {
           continue;
         }
+      } else if (record.type === "attributes") {
+        // attributeFilter below is ["lang"], so any "attributes" record IS a
+        // lang change. The scope a node resolves its locale from can now
+        // differ even though the node's own value hasn't -- e.g. a subtree
+        // whose ancestor gained or lost `lang` -- so the skip caches can no
+        // longer be trusted.
+        langMutated = true;
       }
       externalMutation = true;
+    }
+
+    if (langMutated) {
+      __invalidateValueCaches();
     }
 
     if (externalMutation) {
@@ -1171,6 +1255,7 @@ export function configureLocalization(config = null) {
   __localizationState.requestedKeys.clear();
   __localizationState.textNodeKeyMap = new WeakMap();
   __localizationState.attributeKeyMap = new WeakMap();
+  __invalidateValueCaches();
   __localizationState.valueToKeys.clear();
   __localizationState.messageValueToKeys.clear();
   __localizationState.missingWarnings.clear();
@@ -1226,6 +1311,12 @@ export async function setLocale(locale, { load = true } = {}) {
   if (load) {
     await __loadLocaleInternal(__localizationState.defaultLocale, "set-default");
   }
+  // For an ALREADY-loaded bundle, __loadLocaleInternal returns early and
+  // __setLocaleMessages never runs, so nothing would otherwise invalidate the
+  // skip caches -- making a switch to a previously-visited locale a silent
+  // no-op. Explicit here, rather than relying on __setLocaleMessages, because
+  // that early-return path is exactly the case that needs covering.
+  __invalidateValueCaches();
   __scheduleReconcile();
   return __localizationState.defaultLocale;
 }
@@ -1258,10 +1349,17 @@ export const msg = (template, options = {}) => {
   }
 
   const key = String(template);
-  __registerRequestedKey(key);
+  const isNewKey = __registerRequestedKey(key);
   const translated = __resolveTranslation(key, [], options, null);
 
+  // Gated on isNewKey, not just "was this called": DOM changes are already
+  // covered by the MutationObserver, so a repeat msg() call for an
+  // already-registered key has nothing new to reconcile. Without this gate, a
+  // render-heavy app calling msg() for the same keys on every render would
+  // mark every in-flight pass dirty continuously, turning the reconciler's
+  // "did not settle" warning into noise.
   if (
+    isNewKey &&
     !options?.element &&
     !options?.scope &&
     !options?.host &&

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -3,6 +3,7 @@ import { pdsLog } from "./pds-log.js";
 const __DEFAULT_LOCALE__ = "en";
 const __RECONCILE_DEBOUNCE_MS = 16;
 const __MAX_RECONCILE_PASSES = 5;
+const __MAX_INDEXED_VALUES = 1000;
 
 /**
  * Key under which the one true localization state lives on the global scope.
@@ -347,11 +348,29 @@ function __indexTranslatedValue(key, value) {
     return;
   }
 
-  if (!__localizationState.valueToKeys.has(translatedValue)) {
-    __localizationState.valueToKeys.set(translatedValue, new Set());
+  const index = __localizationState.valueToKeys;
+  let keys = index.get(translatedValue);
+
+  if (!keys) {
+    // FIFO eviction on Map insertion order -- a `while`, not an `if`, so a
+    // lowered cap still converges. Without this the index (and the O(index)
+    // per-node scan in __findRequestedSubsegmentForText) grows for the
+    // lifetime of a session. Accepted trade-off: __findRequestedSubsegmentForText
+    // reads only this index, not messageValueToKeys, so evicting a value can
+    // silently stop a subsegment match from firing once the cap is exceeded.
+    while (index.size >= __MAX_INDEXED_VALUES) {
+      const oldest = index.keys().next();
+      if (oldest.done) {
+        break;
+      }
+      index.delete(oldest.value);
+    }
+
+    keys = new Set();
+    index.set(translatedValue, keys);
   }
 
-  __localizationState.valueToKeys.get(translatedValue).add(key);
+  keys.add(key);
 }
 
 function __getLocaleMessages(locale) {
@@ -1216,6 +1235,7 @@ export function getLocalizationState() {
     messages: { ...(defaultBundle?.messages || {}) },
     loadedLocales: Array.from(__localizationState.messagesByLocale.keys()),
     hasProvider: Boolean(__localizationState.provider),
+    indexedValueCount: __localizationState.valueToKeys.size,
   };
 }
 

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -406,7 +406,7 @@ function __resolveContextLocale(options = {}) {
   return __localizationState.defaultLocale;
 }
 
-function __collectDetectedLocales() {
+function __collectDetectedLocales(roots = []) {
   const detected = new Set([__localizationState.defaultLocale]);
 
   if (typeof document === "undefined") {
@@ -418,11 +418,27 @@ function __collectDetectedLocales() {
     detected.add(__resolveLocaleCandidate(rootLang));
   }
 
-  const nodes = document.querySelectorAll?.("[lang]") || [];
-  for (const node of nodes) {
-    const lang = __normalizeLocale(node.getAttribute("lang"));
-    if (lang) {
-      detected.add(__resolveLocaleCandidate(lang));
+  const addLangFrom = (scanRoot) => {
+    const nodes = scanRoot?.querySelectorAll?.("[lang]") || [];
+    for (const node of nodes) {
+      const lang = __normalizeLocale(node.getAttribute("lang"));
+      if (lang) {
+        detected.add(__resolveLocaleCandidate(lang));
+      }
+    }
+  };
+
+  addLangFrom(document);
+
+  // document.querySelectorAll does not pierce shadow boundaries, but
+  // __resolveContextLocale can resolve a `lang` set inside one (via
+  // closest("[lang]") on a shadow-internal element). Without this, a
+  // shadow-scoped locale gets loaded once and then pruned again on every
+  // subsequent pass, since __pruneUndetectedLocales only keeps locales this
+  // function reports.
+  for (const root of roots) {
+    if (root && root !== document) {
+      addLangFrom(root);
     }
   }
 
@@ -685,17 +701,28 @@ async function __localizeTextNode(textNode) {
   __setTextNodeValue(textNode, nextText);
 }
 
-async function __localizeRequestedTextNodes() {
-  if (typeof document === "undefined" || __localizationState.requestedKeys.size === 0) {
-    return;
+/**
+ * Snapshots every localization root (document.body plus every shadow root
+ * reachable from it) and every element in those roots, in one walk.
+ *
+ * Previously __localizeRequestedTextNodes and __localizeRequestedAttributes
+ * each independently rediscovered the shadow-root list via their own
+ * querySelectorAll("*"), and __localizeRequestedAttributes did it a second
+ * time for its own element loop -- three full-tree element snapshots per
+ * pass where one suffices.
+ */
+function __collectLocalizationRoots() {
+  if (typeof document === "undefined") {
+    return { roots: [], elements: [] };
   }
 
   const root = document.body || document.documentElement;
-  if (!root || typeof document.createTreeWalker !== "function") {
-    return;
+  if (!root) {
+    return { roots: [], elements: [] };
   }
 
   const roots = [];
+  const elements = [];
   const seenRoots = new Set();
 
   const addRoot = (candidateRoot) => {
@@ -715,13 +742,27 @@ async function __localizeRequestedTextNodes() {
       continue;
     }
 
-    const elements = currentRoot.querySelectorAll("*");
-    for (const element of elements) {
+    const rootElements = currentRoot.querySelectorAll("*");
+    for (const element of rootElements) {
+      elements.push(element);
+
       const shadowRoot = element?.shadowRoot;
       if (shadowRoot) {
         addRoot(shadowRoot);
       }
     }
+  }
+
+  return { roots, elements };
+}
+
+async function __localizeRequestedTextNodes(roots) {
+  if (
+    typeof document === "undefined" ||
+    __localizationState.requestedKeys.size === 0 ||
+    typeof document.createTreeWalker !== "function"
+  ) {
+    return;
   }
 
   const nodes = [];
@@ -807,66 +848,38 @@ async function __localizeAttribute(element, attrName) {
   }
 }
 
-async function __localizeRequestedAttributes() {
+async function __localizeRequestedAttributes(elements) {
   if (typeof document === "undefined" || __localizationState.requestedKeys.size === 0) {
     return;
   }
 
-  const root = document.body || document.documentElement;
-  if (!root) {
-    return;
-  }
-
-  const roots = [];
-  const seenRoots = new Set();
-
-  const addRoot = (candidateRoot) => {
-    if (!candidateRoot || seenRoots.has(candidateRoot)) {
-      return;
-    }
-
-    seenRoots.add(candidateRoot);
-    roots.push(candidateRoot);
-  };
-
-  addRoot(root);
-
-  for (let index = 0; index < roots.length; index += 1) {
-    const currentRoot = roots[index];
-    if (!currentRoot || typeof currentRoot.querySelectorAll !== "function") {
-      continue;
-    }
-
-    const elements = currentRoot.querySelectorAll("*");
-    for (const element of elements) {
-      const shadowRoot = element?.shadowRoot;
-      if (shadowRoot) {
-        addRoot(shadowRoot);
-      }
-    }
-  }
-
-  for (const scanRoot of roots) {
-    if (!scanRoot || typeof scanRoot.querySelectorAll !== "function") {
-      continue;
-    }
-
-    const elements = scanRoot.querySelectorAll("*");
-    for (const element of elements) {
-      for (const attrName of __LOCALIZABLE_ATTRIBUTES) {
-        if (element.hasAttribute(attrName)) {
-          await __localizeAttribute(element, attrName);
-        }
+  for (const element of elements) {
+    for (const attrName of __LOCALIZABLE_ATTRIBUTES) {
+      if (element.hasAttribute(attrName)) {
+        await __localizeAttribute(element, attrName);
       }
     }
   }
 }
 
 async function __reconcileLocalization() {
-  const detectedLocales = __collectDetectedLocales();
+  // Collecting roots/elements walks the whole tree, so skip it entirely when
+  // there is nothing registered to localize -- matching the bail-out
+  // __localizeRequestedTextNodes/__localizeRequestedAttributes each used to
+  // do independently.
+  const hasRequestedKeys = __localizationState.requestedKeys.size > 0;
+  const { roots, elements } = hasRequestedKeys
+    ? __collectLocalizationRoots()
+    : { roots: [], elements: [] };
+
+  const detectedLocales = __collectDetectedLocales(roots);
   await __ensureDetectedLocalesLoaded(detectedLocales);
-  await __localizeRequestedTextNodes();
-  await __localizeRequestedAttributes();
+
+  if (hasRequestedKeys) {
+    await __localizeRequestedTextNodes(roots);
+    await __localizeRequestedAttributes(elements);
+  }
+
   __pruneUndetectedLocales(detectedLocales);
 }
 

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -2,19 +2,111 @@ import { pdsLog } from "./pds-log.js";
 
 const __DEFAULT_LOCALE__ = "en";
 
-const __localizationState = {
-  defaultLocale: __DEFAULT_LOCALE__,
-  provider: null,
-  messagesByLocale: new Map(),
-  loadingByLocale: new Map(),
-  observer: null,
-  reconcileTimer: null,
-  requestedKeys: new Set(),
-  textNodeKeyMap: new WeakMap(),
-  attributeKeyMap: new WeakMap(),
-  valueToKeys: new Map(),
-  missingWarnings: new Set(),
-};
+/**
+ * Key under which the one true localization state lives on the global scope.
+ *
+ * The string is duplicated rather than imported, matching how `pds-log.js`
+ * reaches `__PURE_DS_PDS_SINGLETON__`: modules under `common/` are leaf
+ * utilities and must not depend on `pds-singleton.js`. Importing it would also
+ * give `import "@pure-ds/core/localization"` the side effect of instantiating
+ * the PDS singleton, and would make this bundle -- which is loaded dynamically
+ * and may evaluate before, after, or entirely without `pds.js` -- depend on
+ * load order.
+ */
+const __LOCALIZATION_STATE_KEY = "__PURE_DS_LOCALIZATION_STATE__";
+
+function __createLocalizationState() {
+  return {
+    defaultLocale: __DEFAULT_LOCALE__,
+    provider: null,
+    messagesByLocale: new Map(),
+    loadingByLocale: new Map(),
+    observer: null,
+    reconcileTimer: null,
+    requestedKeys: new Set(),
+    textNodeKeyMap: new WeakMap(),
+    attributeKeyMap: new WeakMap(),
+    valueToKeys: new Map(),
+    missingWarnings: new Set(),
+    configureCount: 0,
+  };
+}
+
+/**
+ * Backfill fields an older copy of this module may not have created.
+ *
+ * Must test with `in`, never `||=` or `??=`: `provider`, `observer` and
+ * `reconcileTimer` are legitimately falsy, so a truthiness test would clobber
+ * live values -- including, once the reconciler serializes its passes, the
+ * in-flight latch that makes concurrent copies safe.
+ */
+function __adoptLocalizationState(existingState) {
+  const defaults = __createLocalizationState();
+  for (const field of Object.keys(defaults)) {
+    if (!(field in existingState)) {
+      existingState[field] = defaults[field];
+    }
+  }
+  return existingState;
+}
+
+function __resolveGlobalScope() {
+  try {
+    if (typeof globalThis !== "undefined") return globalThis;
+    if (typeof window !== "undefined") return window;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Resolve the single source of truth for localization state, shared by every
+ * copy of this module in the realm.
+ *
+ * Several `@pure-ds/core` bundles statically inline this file
+ * (`pds-localization.js`, `pds-enhancers.js`, `pds-manager.js`) and a consumer
+ * may bundle a further copy, so module-level state would fork: only the copy
+ * that receives `configureLocalization()` would work, and every `msg()` call in
+ * the others would return its raw key. Two configured copies would run two
+ * MutationObservers over one document, each seeing the other's writes as
+ * external mutations.
+ *
+ * INVARIANT: the state OBJECT identity is never replaced -- only its fields are
+ * mutated. Every access in this file goes through `__localizationState.<field>`,
+ * so a field reassignment (as `configureLocalization` does for the key maps) is
+ * immediately visible to all copies. Never reassign `__localizationState`, and
+ * never destructure a field into a module-level binding: either re-forks the
+ * state silently.
+ *
+ * Fields are append-only, because the object is a contract across versions. If
+ * a breaking shape change is ever needed, change the KEY rather than the shape
+ * -- refusing to adopt an older-shaped state would recreate the fork this
+ * exists to remove.
+ */
+function __resolveLocalizationState() {
+  const scope = __resolveGlobalScope();
+  if (!scope) {
+    return __createLocalizationState();
+  }
+
+  const existingState = scope[__LOCALIZATION_STATE_KEY];
+  if (existingState && typeof existingState === "object") {
+    return __adoptLocalizationState(existingState);
+  }
+
+  const createdState = __createLocalizationState();
+  try {
+    scope[__LOCALIZATION_STATE_KEY] = createdState;
+  } catch {
+    // Frozen or sealed global (hardened realms, some CSP shims): degrade to
+    // per-copy state, which is the pre-fix behaviour. Never throw from module
+    // evaluation.
+  }
+  return createdState;
+}
+
+const __localizationState = __resolveLocalizationState();
 
 const __LOCALIZABLE_ATTRIBUTES = [
   "title",
@@ -780,9 +872,12 @@ function __attachLangObserver() {
     return;
   }
 
+  // Exactly one observer must exist per realm, however many copies of this
+  // module are loaded. Re-creating it on every configure would swap a working
+  // observer for an identical one and open a window in which mutations are
+  // missed, so an already-attached observer is left alone.
   if (__localizationState.observer) {
-    __localizationState.observer.disconnect();
-    __localizationState.observer = null;
+    return;
   }
 
   if (typeof MutationObserver !== "function") {
@@ -802,6 +897,13 @@ function __attachLangObserver() {
   });
 
   __localizationState.observer = observer;
+}
+
+function __detachLangObserver() {
+  if (__localizationState.observer) {
+    __localizationState.observer.disconnect();
+    __localizationState.observer = null;
+  }
 }
 
 function __resolveTranslation(key, values = [], options = {}, template = null) {
@@ -887,10 +989,29 @@ export function getLocalizationState() {
 }
 
 export function configureLocalization(config = null) {
-  if (__localizationState.observer) {
-    __localizationState.observer.disconnect();
-    __localizationState.observer = null;
+  // The state is shared across every copy of this module in the realm, so a
+  // second call tears down the first caller's configuration. That is the
+  // documented contract, but it is also the likeliest cause of a "my provider
+  // disappeared" report, so make it visible.
+  __localizationState.configureCount += 1;
+  if (__localizationState.configureCount > 1) {
+    const incomingLocale =
+      typeof config?.locale === "string" && config.locale.trim()
+        ? config.locale
+        : __DEFAULT_LOCALE__;
+    pdsLog(
+      "debug",
+      `[i18n] configureLocalization() call #${__localizationState.configureCount} replaces the previous configuration (incoming locale "${incomingLocale}"${
+        config ? "" : ", resetting to defaults"
+      }).`
+    );
   }
+
+  // The observer is deliberately NOT disconnected here. It is realm-wide and
+  // idempotent (see __attachLangObserver), and it observes only `lang` plus
+  // structure -- nothing that the configuration changes. MutationObserver
+  // callbacks are microtasks and reconcile is a macrotask, so neither can
+  // interleave with this synchronous reset.
   if (__localizationState.reconcileTimer) {
     clearTimeout(__localizationState.reconcileTimer);
     __localizationState.reconcileTimer = null;
@@ -907,6 +1028,11 @@ export function configureLocalization(config = null) {
   __localizationState.missingWarnings.clear();
 
   if (!config || typeof config !== "object") {
+    // A reset leaves nothing to reconcile for, and this path never reaches
+    // __attachLangObserver, so the observer must be torn down here or it would
+    // keep running a document-wide "[lang]" query on every mutation batch for
+    // the rest of the page's life.
+    __detachLangObserver();
     return getLocalizationState();
   }
 

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -32,6 +32,7 @@ function __createLocalizationState() {
     textNodeKeyMap: new WeakMap(),
     attributeKeyMap: new WeakMap(),
     valueToKeys: new Map(),
+    messageValueToKeys: new Map(),
     missingWarnings: new Set(),
     configureCount: 0,
   };
@@ -247,12 +248,47 @@ function __localeVariants(locale) {
   return [normalized, base];
 }
 
+/**
+ * Rebuilds the authoritative value -> requested-key(s) index from every
+ * loaded locale bundle. Replaces the map wholesale rather than patching it in
+ * place, since a removed or changed key can't be found to unindex without
+ * rescanning anyway.
+ *
+ * This is what __findRequestedKeyForText's third tier reads instead of its
+ * former nested "for each requested key, for each loaded locale" scan.
+ */
+function __rebuildMessageValueIndex() {
+  const index = new Map();
+
+  for (const messages of __localizationState.messagesByLocale.values()) {
+    if (!messages) {
+      continue;
+    }
+
+    for (const [key, value] of Object.entries(messages)) {
+      if (typeof value !== "string" || !value.length) {
+        continue;
+      }
+
+      let keys = index.get(value);
+      if (!keys) {
+        keys = new Set();
+        index.set(value, keys);
+      }
+      keys.add(key);
+    }
+  }
+
+  __localizationState.messageValueToKeys = index;
+}
+
 function __setLocaleMessages(locale, messages) {
   const normalizedLocale = __resolveLocaleCandidate(locale);
   __localizationState.messagesByLocale.set(
     normalizedLocale,
     __normalizeMessages(messages)
   );
+  __rebuildMessageValueIndex();
 }
 
 function __registerRequestedKey(key) {
@@ -452,10 +488,20 @@ async function __ensureDetectedLocalesLoaded(detectedLocales) {
 }
 
 function __pruneUndetectedLocales(detectedLocales) {
+  let removedAny = false;
+
   for (const loadedLocale of Array.from(__localizationState.messagesByLocale.keys())) {
     if (!detectedLocales.has(loadedLocale)) {
       __localizationState.messagesByLocale.delete(loadedLocale);
+      removedAny = true;
     }
+  }
+
+  // Guarded on removedAny: this runs at the end of every pass, and in steady
+  // state nothing is removed, so an unconditional rebuild here would redo the
+  // full-index scan on every settle for no reason.
+  if (removedAny) {
+    __rebuildMessageValueIndex();
   }
 }
 
@@ -563,10 +609,17 @@ function __findRequestedKeyForText(coreText) {
     return coreText;
   }
 
-  const loadedEntries = Array.from(__localizationState.messagesByLocale.entries());
-  for (const key of __localizationState.requestedKeys) {
-    for (const [, messages] of loadedEntries) {
-      if (messages && messages[key] === coreText) {
+  // Formerly an O(requestedKeys x loaded locales) scan re-run for every text
+  // node on every pass; __rebuildMessageValueIndex keeps this map current
+  // instead. A tie (two requested keys sharing one locale's translated
+  // value) can pick a different key than the old insertion-order scan did,
+  // but whichever key is chosen translates back to this same coreText, so the
+  // rendered output is unaffected -- only textNodeKeyMap/attributeKeyMap
+  // bookkeeping could differ.
+  const messageKeys = __localizationState.messageValueToKeys.get(coreText);
+  if (messageKeys) {
+    for (const key of messageKeys) {
+      if (__localizationState.requestedKeys.has(key)) {
         return key;
       }
     }
@@ -1119,6 +1172,7 @@ export function configureLocalization(config = null) {
   __localizationState.textNodeKeyMap = new WeakMap();
   __localizationState.attributeKeyMap = new WeakMap();
   __localizationState.valueToKeys.clear();
+  __localizationState.messageValueToKeys.clear();
   __localizationState.missingWarnings.clear();
 
   if (!config || typeof config !== "object") {

--- a/src/js/common/localization.js
+++ b/src/js/common/localization.js
@@ -1175,11 +1175,23 @@ function __resolveTranslation(key, values = [], options = {}, template = null) {
     locale: requestedLocale,
     defaultLocale: __localizationState.defaultLocale,
     messages: targetMessages,
-    messagesByLocale: Object.fromEntries(
-      Array.from(__localizationState.messagesByLocale.entries())
-    ),
     template,
   };
+
+  // __resolveTranslation runs once per localizable node per pass, plus once
+  // per msg() call, so materializing every loaded locale's messages here
+  // unconditionally is O(locales x nodes) allocation for providers that never
+  // read this field -- the common case, since most read only `messages`
+  // (the already-resolved target locale) or `key`. A lazy getter defers that
+  // cost to providers that actually access it; enumerable/configurable keeps
+  // spread, Object.keys, and JSON.stringify seeing and correctly resolving it.
+  Object.defineProperty(context, "messagesByLocale", {
+    enumerable: true,
+    configurable: true,
+    get() {
+      return Object.fromEntries(__localizationState.messagesByLocale.entries());
+    },
+  });
 
   let translated;
   const localeLoaded = Boolean(resolvedMessages);

--- a/src/js/common/localization.shared-state.test.mjs
+++ b/src/js/common/localization.shared-state.test.mjs
@@ -1,0 +1,204 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Several @pure-ds/core bundles statically inline common/localization.js, and a
+ * consumer may bundle a further copy, so these tests load the module more than
+ * once and assert that the copies share one state object.
+ *
+ * ISOLATION CAVEAT: a copy captures the state object once, at import time
+ * (`const __localizationState = __resolveLocalizationState()`). Deleting
+ * globalThis[STATE_KEY] afterwards does NOT detach an already-loaded copy. So
+ * every test must reset the global BEFORE loading its copies, and no copy may
+ * ever be shared between tests -- hence the monotonic counter, which guarantees
+ * a distinct specifier and therefore a distinct module instance.
+ *
+ * No DOM is needed: every DOM touch in the module under test is guarded by a
+ * `typeof document === "undefined"` / `typeof window === "undefined"` check.
+ */
+const STATE_KEY = "__PURE_DS_LOCALIZATION_STATE__";
+const MODULE_URL = new URL("./localization.js", import.meta.url).href;
+
+let __copyCounter = 0;
+
+function loadCopy() {
+  __copyCounter += 1;
+  return import(`${MODULE_URL}?copy=${__copyCounter}`);
+}
+
+function resetSharedState() {
+  delete globalThis[STATE_KEY];
+}
+
+test("two loaded copies of the localization module are genuinely distinct instances", async () => {
+  resetSharedState();
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    // Guards every other test in this file: if the cache-busted import ever
+    // stops producing separate module instances, the sharing assertions below
+    // would pass trivially without testing anything.
+    assert.notStrictEqual(copyA.msg, copyB.msg);
+    assert.notStrictEqual(copyA.configureLocalization, copyB.configureLocalization);
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("configuring one copy configures every copy", async () => {
+  resetSharedState();
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    copyA.configureLocalization({
+      locale: "nl",
+      messages: { Hello: "Hallo" },
+    });
+
+    // Before the shared-state fix copy B kept its own state: "Hello" / "en".
+    assert.equal(copyB.msg("Hello"), "Hallo");
+    assert.equal(copyB.getLocalizationState().locale, "nl");
+    assert.deepEqual(copyB.getLocalizationState().loadedLocales, ["nl"]);
+    assert.equal(copyB.getLocalizationState().hasProvider, false);
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("a key requested through one copy is registered for every copy", async () => {
+  resetSharedState();
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    copyB.configureLocalization({
+      locale: "nl",
+      messages: { "Registered by A": "Door A geregistreerd" },
+    });
+
+    copyA.msg("Registered by A");
+
+    // White-box, because requestedKeys has no public getter -- this mirrors the
+    // heap-snapshot inspection that surfaced the bug. The registry is what the
+    // reconciler walks the DOM for, so a per-copy registry means msg() calls
+    // made inside pds-enhancers.js / pds-live.js are never localized.
+    const sharedState = globalThis[STATE_KEY];
+    assert.ok(sharedState, "expected the shared localization state to exist");
+    assert.ok(sharedState.requestedKeys.has("Registered by A"));
+
+    assert.equal(copyB.msg("Registered by A"), "Door A geregistreerd");
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("adopting an older-shaped state backfills missing fields without clobbering present ones", async () => {
+  resetSharedState();
+
+  try {
+    // An empty string is a legitimate value that is also falsy, so it only
+    // survives if the backfill tests with `in` rather than `||=` / `??=`.
+    globalThis[STATE_KEY] = { defaultLocale: "" };
+
+    const copy = await loadCopy();
+    const adoptedState = globalThis[STATE_KEY];
+
+    assert.equal(adoptedState.defaultLocale, "");
+    assert.equal(copy.getLocalizationState().locale, "");
+
+    assert.ok(adoptedState.messagesByLocale instanceof Map);
+    assert.ok(adoptedState.loadingByLocale instanceof Map);
+    assert.ok(adoptedState.requestedKeys instanceof Set);
+    assert.ok(adoptedState.missingWarnings instanceof Set);
+    assert.ok(adoptedState.valueToKeys instanceof Map);
+    assert.ok(adoptedState.textNodeKeyMap instanceof WeakMap);
+    assert.ok(adoptedState.attributeKeyMap instanceof WeakMap);
+    assert.equal(adoptedState.provider, null);
+    assert.equal(adoptedState.observer, null);
+    assert.equal(adoptedState.reconcileTimer, null);
+    assert.equal(adoptedState.configureCount, 0);
+  } finally {
+    resetSharedState();
+  }
+});
+
+test("one observer is attached across copies, and a reset tears it down", async () => {
+  resetSharedState();
+
+  // Deliberately a stub, not a DOM shim: the assertions below are "how many
+  // observers were constructed" and "was disconnect() called", not anything
+  // about MutationObserver semantics. Record/replay behaviour of the observer
+  // itself is covered by the jsdom-based reconciler tests.
+  const observers = [];
+  const saved = {
+    window: globalThis.window,
+    document: globalThis.document,
+    MutationObserver: globalThis.MutationObserver,
+  };
+
+  globalThis.window = {};
+  globalThis.document = { documentElement: { getAttribute: () => null } };
+  globalThis.MutationObserver = class {
+    constructor() {
+      this.disconnected = false;
+      observers.push(this);
+    }
+    observe() {}
+    disconnect() {
+      this.disconnected = true;
+    }
+  };
+
+  try {
+    const copyA = await loadCopy();
+    const copyB = await loadCopy();
+
+    copyA.configureLocalization({ locale: "nl", messages: { Hello: "Hallo" } });
+    assert.equal(observers.length, 1);
+
+    // A second configure through a different copy must not stack a second
+    // observer over the same document.
+    copyB.configureLocalization({ locale: "de", messages: { Hello: "Hallo" } });
+    assert.equal(observers.length, 1);
+    assert.equal(observers[0].disconnected, false);
+
+    // A reset has nothing left to reconcile for, so the observer must go --
+    // otherwise it keeps scheduling document-wide passes forever.
+    copyB.configureLocalization(null);
+    assert.equal(observers[0].disconnected, true);
+    assert.equal(globalThis[STATE_KEY].observer, null);
+  } finally {
+    globalThis.window = saved.window;
+    globalThis.document = saved.document;
+    globalThis.MutationObserver = saved.MutationObserver;
+    resetSharedState();
+  }
+});
+
+test("a global that rejects the write degrades to per-copy state instead of throwing", async () => {
+  resetSharedState();
+
+  // Hardened realms and some CSP shims make the global non-writable. Module
+  // evaluation must still succeed; falling back to per-copy state is the
+  // pre-fix behaviour, which is degraded but not broken.
+  Object.defineProperty(globalThis, STATE_KEY, {
+    value: 0,
+    writable: false,
+    configurable: true,
+  });
+
+  try {
+    const copy = await loadCopy();
+
+    assert.equal(globalThis[STATE_KEY], 0);
+    assert.equal(copy.msg("untranslated"), "untranslated");
+    assert.equal(copy.getLocalizationState().locale, "en");
+  } finally {
+    delete globalThis[STATE_KEY];
+  }
+});

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -1,0 +1,214 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+
+import {
+  configureLocalization,
+  getLocalizationState,
+  msg,
+  setLocale,
+} from "./localization.js";
+import { configurePDSLogger } from "./pds-log.js";
+
+/**
+ * DOM tests for the localization reconciler.
+ *
+ * jsdom rather than a lighter shim, because what these tests pin IS observer
+ * semantics: record type, record.target identity, attributeFilter, and
+ * microtask delivery ordering relative to the reconciler's awaits. linkedom
+ * cannot express them -- its mutation observer only ever emits
+ * type: "childList" records whose target is the observed node, so the
+ * reconciler's self-write filter would never execute and the test would pass
+ * having verified nothing.
+ *
+ * NOTE ON `lang`: the test documents deliberately have no `lang` attribute on
+ * <html>. __resolveContextLocale resolves a text node's locale via
+ * parentElement.closest("[lang]") first, so a `lang` on <html> would pin every
+ * node to that locale instead of the configured default.
+ */
+
+const DEBOUNCE_MS = 16;
+
+let __installedDom = null;
+
+function installDom(bodyHtml) {
+  const dom = new JSDOM(`<!doctype html><html><body>${bodyHtml}</body></html>`);
+  const { window } = dom;
+
+  const saved = {};
+  const install = (name, value) => {
+    saved[name] = globalThis[name];
+    globalThis[name] = value;
+  };
+
+  install("window", window);
+  install("document", window.document);
+  install("MutationObserver", window.MutationObserver);
+  install("NodeFilter", window.NodeFilter);
+  install("Node", window.Node);
+  install("Element", window.Element);
+
+  // __collectDetectedLocales is the only caller of document.querySelectorAll
+  // with the "[lang]" selector, and it runs exactly once per reconcile pass, so
+  // wrapping it counts passes without any seam in production code.
+  const originalQuerySelectorAll = window.document.querySelectorAll.bind(window.document);
+  const counter = { passes: 0 };
+  window.document.querySelectorAll = (selector) => {
+    if (selector === "[lang]") counter.passes += 1;
+    return originalQuerySelectorAll(selector);
+  };
+
+  __installedDom = {
+    dom,
+    counter,
+    restore() {
+      for (const [name, value] of Object.entries(saved)) {
+        if (value === undefined) {
+          delete globalThis[name];
+        } else {
+          globalThis[name] = value;
+        }
+      }
+      window.close();
+    },
+  };
+
+  return __installedDom;
+}
+
+function teardownDom() {
+  if (!__installedDom) return;
+  // Detaches the MutationObserver bound to this document. Without it the next
+  // test's configureLocalization() would find state.observer already set and
+  // skip attaching to its own, fresh document.
+  configureLocalization(null);
+  configurePDSLogger({});
+  __installedDom.restore();
+  __installedDom = null;
+}
+
+const flush = (ms = DEBOUNCE_MS * 6) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+function captureLogs() {
+  const entries = [];
+  configurePDSLogger({
+    getLogger: () => (level, message, ...data) => {
+      entries.push([level, String(message), ...data]);
+    },
+  });
+  return entries;
+}
+
+/** A provider serving fixed bundles, recording how often translate() ran. */
+function bundleProvider(bundlesByLocale) {
+  const stats = { translateCalls: 0, loadCalls: [] };
+  return {
+    stats,
+    provider: {
+      loadLocale: ({ locale }) => {
+        stats.loadCalls.push(locale);
+        return bundlesByLocale[locale] || {};
+      },
+      translate: ({ key, messages }) => {
+        stats.translateCalls += 1;
+        return messages?.[key];
+      },
+    },
+  };
+}
+
+const NL_DE = {
+  nl: { Hello: "Hallo", Goodbye: "Tot ziens" },
+  de: { Hello: "Guten Tag", Goodbye: "Auf Wiedersehen" },
+};
+
+test("text and attributes inside shadow roots are localized", async () => {
+  const { dom } = installDom(`<p>Hello</p><div id="host"></div>`);
+  const shadow = dom.window.document
+    .getElementById("host")
+    .attachShadow({ mode: "open" });
+  shadow.innerHTML = `<span title="Goodbye">Hello</span>`;
+
+  try {
+    const { provider } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+    msg("Hello");
+    msg("Goodbye");
+
+    await flush();
+
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+    assert.equal(shadow.querySelector("span").textContent, "Hallo");
+    assert.equal(shadow.querySelector("span").getAttribute("title"), "Tot ziens");
+  } finally {
+    teardownDom();
+  }
+});
+
+test("an external text mutation schedules a pass and is localized", async () => {
+  const { dom } = installDom(`<p>Hello</p><p id="later">untouched</p>`);
+
+  try {
+    const { provider } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+    msg("Hello");
+    msg("Goodbye");
+
+    await flush();
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+
+    // Someone else's write to the DOM must still be picked up. This is the
+    // negative control for the self-write filter: if that filter ever swallows
+    // external mutations, this is what catches it.
+    dom.window.document.getElementById("later").firstChild.nodeValue = "Goodbye";
+    await flush();
+
+    assert.equal(dom.window.document.getElementById("later").textContent, "Tot ziens");
+  } finally {
+    teardownDom();
+  }
+});
+
+test("setLocale() re-localizes nodes that have already settled", async () => {
+  const { dom } = installDom(`<p>Hello</p>`);
+
+  try {
+    const { provider } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+    msg("Hello");
+
+    await flush();
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+
+    await setLocale("de");
+    await flush();
+
+    assert.equal(getLocalizationState().locale, "de");
+    assert.equal(dom.window.document.querySelector("p").textContent, "Guten Tag");
+  } finally {
+    teardownDom();
+  }
+});
+
+test("a lang attribute change re-localizes nodes that have already settled", async () => {
+  const { dom } = installDom(`<p>Hello</p>`);
+
+  try {
+    const { provider } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+    msg("Hello");
+
+    await flush();
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+
+    dom.window.document.documentElement.setAttribute("lang", "de");
+    await flush();
+
+    assert.equal(dom.window.document.querySelector("p").textContent, "Guten Tag");
+  } finally {
+    teardownDom();
+  }
+});
+
+export { installDom, teardownDom, flush, captureLogs, bundleProvider, NL_DE, DEBOUNCE_MS };

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -211,4 +211,104 @@ test("a lang attribute change re-localizes nodes that have already settled", asy
   }
 });
 
+test("reconcile passes are serialized while one is in flight", async () => {
+  const { dom, counter } = installDom(`<p>Hello</p>`);
+
+  try {
+    let releaseLoad;
+    const loadGate = new Promise((resolve) => {
+      releaseLoad = resolve;
+    });
+
+    configureLocalization({
+      locale: "nl",
+      provider: {
+        loadLocale: async ({ locale }) => {
+          if (locale === "nl") await loadGate;
+          return NL_DE[locale] || {};
+        },
+      },
+    });
+    msg("Hello");
+
+    // Let the debounced timer fire once; the pass then hangs inside
+    // __ensureDetectedLocalesLoaded, awaiting loadGate.
+    await flush(DEBOUNCE_MS * 2);
+    const passesWhileHanging = counter.passes;
+    assert.equal(passesWhileHanging, 1);
+
+    // Each mutation is spaced beyond the debounce window, so every one of
+    // them genuinely fires its own timer callback. Before serialization each
+    // of those un-awaited calls started its own concurrent document walk.
+    for (let i = 0; i < 5; i += 1) {
+      dom.window.document.body.appendChild(dom.window.document.createElement("span"));
+      await flush(DEBOUNCE_MS * 1.5);
+    }
+    assert.equal(
+      counter.passes,
+      passesWhileHanging,
+      "a pass must not start while one is already in flight"
+    );
+
+    releaseLoad();
+    await flush(DEBOUNCE_MS * 8);
+
+    // Serialization must not drop the work the coalesced mutations asked for.
+    assert.ok(counter.passes <= 3, `expected a small, bounded number of passes, got ${counter.passes}`);
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+  } finally {
+    teardownDom();
+  }
+});
+
+test("non-settling localization warns and reschedules the remainder", async () => {
+  const { dom } = installDom(`<p>Hello</p>`);
+  const logs = captureLogs();
+
+  try {
+    let translateCalls = 0;
+    configureLocalization({
+      locale: "nl",
+      provider: {
+        // Every call appends a fresh, localizable node, so no pass can ever
+        // observe a settled DOM -- this is the pathological case the pass
+        // cap exists for.
+        translate: ({ key, messages }) => {
+          translateCalls += 1;
+          if (translateCalls <= 40) {
+            const churn = dom.window.document.createElement("p");
+            churn.textContent = "Hello";
+            dom.window.document.body.appendChild(churn);
+          }
+          return messages?.[key] ?? NL_DE.nl[key];
+        },
+        loadLocale: ({ locale }) => NL_DE[locale] || {},
+      },
+    });
+    msg("Hello");
+
+    // Sample right as the cap is hit, not after the DOM has fully settled --
+    // otherwise the rescheduled window's work has already happened and there
+    // is nothing left to observe growing.
+    let sawWarning = false;
+    for (let i = 0; i < 10 && !sawWarning; i += 1) {
+      await flush(DEBOUNCE_MS);
+      sawWarning = logs.some(([level, message]) => level === "warn" && /did not settle/.test(message));
+    }
+    assert.ok(sawWarning, "expected a warning once the pass cap was hit");
+
+    const translateCallsAtWarning = translateCalls;
+    await flush(DEBOUNCE_MS * 2);
+
+    // The cap bounds latency per scheduling window, not total work: proof
+    // that the remainder was rescheduled rather than silently dropped.
+    assert.ok(
+      translateCalls > translateCallsAtWarning,
+      "expected work to continue in the rescheduled window"
+    );
+  } finally {
+    teardownDom();
+  }
+});
+
 export { installDom, teardownDom, flush, captureLogs, bundleProvider, NL_DE, DEBOUNCE_MS };

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -548,4 +548,43 @@ test("the translated-value index is capped", async () => {
   }
 });
 
+test("the translate context's messagesByLocale is computed lazily", async () => {
+  installDom(``);
+  const originalFromEntries = Object.fromEntries;
+  let fromEntriesCalls = 0;
+  Object.fromEntries = (...args) => {
+    fromEntriesCalls += 1;
+    return originalFromEntries(...args);
+  };
+
+  try {
+    // __resolveTranslation runs once per localizable node per pass, plus once
+    // per msg() call, so a provider that never reads messagesByLocale --
+    // the common case, most read only `messages` or `key` -- must never pay
+    // for materializing it.
+    configureLocalization({
+      locale: "nl",
+      messages: { Hello: "Hallo" },
+      provider: { translate: ({ messages, key }) => messages?.[key] },
+    });
+    assert.equal(msg("Hello"), "Hallo");
+    assert.equal(fromEntriesCalls, 0, "expected messagesByLocale to never be materialized");
+
+    // A provider that DOES read it must still see correct, current data --
+    // the getter defers the cost, it must not change the result.
+    configureLocalization({
+      locale: "nl",
+      messages: { Hello: "Hallo" },
+      provider: {
+        translate: ({ messagesByLocale, key, locale }) => messagesByLocale[locale]?.[key],
+      },
+    });
+    assert.equal(msg("Hello"), "Hallo");
+    assert.equal(fromEntriesCalls, 1, "expected exactly one materialization for the one access");
+  } finally {
+    Object.fromEntries = originalFromEntries;
+    teardownDom();
+  }
+});
+
 export { installDom, teardownDom, flush, captureLogs, bundleProvider, NL_DE, DEBOUNCE_MS };

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -48,15 +48,28 @@ function installDom(bodyHtml) {
   install("Node", window.Node);
   install("Element", window.Element);
 
-  // __collectDetectedLocales is the only caller of document.querySelectorAll
-  // with the "[lang]" selector, and it runs exactly once per reconcile pass, so
-  // wrapping it counts passes without any seam in production code.
+  // __collectDetectedLocales always calls document.querySelectorAll("[lang]")
+  // exactly once per reconcile pass (the shadow-scoped scan added alongside
+  // __collectLocalizationRoots calls querySelectorAll on shadow roots
+  // instead, so it does not add to this count), so wrapping it counts passes
+  // without any seam in production code.
   const originalQuerySelectorAll = window.document.querySelectorAll.bind(window.document);
-  const counter = { passes: 0 };
+  const counter = { passes: 0, starSelects: 0 };
   window.document.querySelectorAll = (selector) => {
     if (selector === "[lang]") counter.passes += 1;
     return originalQuerySelectorAll(selector);
   };
+
+  // __collectLocalizationRoots is the only caller of a bare `"*"` selector,
+  // via Element/ShadowRoot.prototype.querySelectorAll, once per root per
+  // pass. Counting it here is what pins the snapshot-sharing refactor.
+  for (const proto of [window.Element.prototype, window.ShadowRoot.prototype]) {
+    const original = proto.querySelectorAll;
+    proto.querySelectorAll = function (selector) {
+      if (selector === "*") counter.starSelects += 1;
+      return original.call(this, selector);
+    };
+  }
 
   __installedDom = {
     dom,
@@ -331,6 +344,87 @@ test("the reconciler's own write does not trigger a redundant extra pass", async
     // And it must stay settled -- no perpetual retriggering off its own writes.
     await flush(DEBOUNCE_MS * 6);
     assert.equal(counter.passes, 1);
+  } finally {
+    teardownDom();
+  }
+});
+
+test("a lang attribute inside a shadow root is detected without being pruned every pass", async () => {
+  const { dom } = installDom(`<div id="host"></div>`);
+  const shadow = dom.window.document.getElementById("host").attachShadow({ mode: "open" });
+  shadow.innerHTML = `<p lang="de">Hello</p>`;
+
+  try {
+    const loadCalls = [];
+    configureLocalization({
+      locale: "nl",
+      provider: {
+        loadLocale: ({ locale }) => {
+          loadCalls.push(locale);
+          return NL_DE[locale] || {};
+        },
+      },
+    });
+    msg("Hello");
+
+    await flush();
+    // __localizeTextNode loads "de" on demand for this node regardless of
+    // __collectDetectedLocales, via __resolveContextLocale resolving `lang`
+    // through the shadow boundary -- so this alone doesn't distinguish the
+    // fix. What it exposes is __pruneUndetectedLocales: without scanning
+    // roots too, document.querySelectorAll("[lang]") cannot see this
+    // shadow-internal attribute, "de" is absent from detectedLocales, and it
+    // gets deleted from messagesByLocale at the end of every single pass --
+    // forcing a re-fetch on every subsequent pass that touches this node.
+    assert.equal(shadow.querySelector("p").textContent, "Guten Tag");
+
+    const deLoadsAfterSettling = loadCalls.filter((l) => l === "de").length;
+
+    // Force a second, genuine pass with nothing about the shadow content
+    // changed, so any further "de" load can only be the prune-and-reload bug.
+    dom.window.document.body.appendChild(dom.window.document.createElement("hr"));
+    await flush();
+
+    assert.equal(
+      loadCalls.filter((l) => l === "de").length,
+      deLoadsAfterSettling,
+      "expected the de bundle to stay loaded, not be pruned and re-fetched"
+    );
+  } finally {
+    teardownDom();
+  }
+});
+
+test("each reconcile pass takes one element snapshot per root", async () => {
+  const { dom, counter } = installDom(`<p>Hello</p><div id="host"></div>`);
+  const shadow = dom.window.document
+    .getElementById("host")
+    .attachShadow({ mode: "open" });
+  shadow.innerHTML = `<span title="Goodbye">Hello</span>`;
+
+  try {
+    const { provider } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+    msg("Hello");
+    msg("Goodbye");
+
+    await flush();
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+
+    const starSelectsAtSettle = counter.starSelects;
+    const passesAtSettle = counter.passes;
+
+    // One unrelated external mutation forces exactly one more pass over the
+    // same two roots (body + the shadow root). Before sharing one snapshot
+    // between the text-node and attribute walks, this cost 3 querySelectorAll
+    // ("*") calls per root (1 in the text-node walk's shadow discovery, 1 in
+    // the attribute walk's own shadow discovery, 1 in the attribute walk's
+    // element loop) -- 6 for 2 roots. After, it costs 1 per root -- 2.
+    dom.window.document.body.appendChild(dom.window.document.createElement("hr"));
+    await flush();
+
+    assert.equal(counter.passes, passesAtSettle + 1);
+    assert.equal(counter.starSelects - starSelectsAtSettle, 2);
   } finally {
     teardownDom();
   }

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -430,4 +430,36 @@ test("each reconcile pass takes one element snapshot per root", async () => {
   }
 });
 
+test("a node already showing another locale's translated value is retranslated via the message-value index", async () => {
+  // The div's own text ("not a key") matches nothing and is left alone; its
+  // sole purpose is to get "fr" detected and loaded. Crucially, no node in
+  // this test is ever translated under "fr" during this session, so
+  // valueToKeys (the observed-translation index) never learns that "Bonjour"
+  // maps to "Hello" -- only the message-defined index, rebuilt from the
+  // loaded fr bundle itself, can find it. This is a characterization: tier 3
+  // of __findRequestedKeyForText is unchanged behavior, only its
+  // implementation moved from an O(requestedKeys x locales) scan to a map
+  // lookup, so this must stay green both before and after that refactor.
+  const { dom } = installDom(
+    `<div lang="fr" style="display:none">not a key</div><p id="target">Bonjour</p>`
+  );
+
+  try {
+    configureLocalization({
+      locale: "nl",
+      provider: {
+        loadLocale: ({ locale }) =>
+          ({ nl: { Hello: "Hallo" }, fr: { Hello: "Bonjour" } })[locale] || {},
+      },
+    });
+    msg("Hello");
+
+    await flush();
+
+    assert.equal(dom.window.document.getElementById("target").textContent, "Hallo");
+  } finally {
+    teardownDom();
+  }
+});
+
 export { installDom, teardownDom, flush, captureLogs, bundleProvider, NL_DE, DEBOUNCE_MS };

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -519,4 +519,33 @@ test("a key registered after a node was first visited is still localized", async
   }
 });
 
+test("the translated-value index is capped", async () => {
+  installDom(``);
+
+  try {
+    configureLocalization({
+      locale: "nl",
+      provider: {
+        translate: ({ key }) => `translated-${key}`,
+      },
+    });
+
+    for (let index = 0; index < 1500; index += 1) {
+      msg(`key-${index}`);
+    }
+
+    assert.ok(
+      getLocalizationState().indexedValueCount <= 1000,
+      `expected the index to stay capped, got ${getLocalizationState().indexedValueCount}`
+    );
+
+    // Eviction is FIFO by insertion order, so the most recently indexed value
+    // must still resolve correctly -- proving the cap doesn't corrupt lookups
+    // for what it keeps, only drops what it evicts.
+    assert.equal(msg("key-1499"), "translated-key-1499");
+  } finally {
+    teardownDom();
+  }
+});
+
 export { installDom, teardownDom, flush, captureLogs, bundleProvider, NL_DE, DEBOUNCE_MS };

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -311,4 +311,29 @@ test("non-settling localization warns and reschedules the remainder", async () =
   }
 });
 
+test("the reconciler's own write does not trigger a redundant extra pass", async () => {
+  const { dom, counter } = installDom(`<p>Hello</p>`);
+
+  try {
+    const { provider } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+    msg("Hello");
+
+    await flush(DEBOUNCE_MS * 6);
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+
+    // The write that settles the DOM produces exactly one characterData
+    // record. Before the self-write filter, that record was indistinguishable
+    // from an external mutation and unconditionally scheduled a second,
+    // entirely wasted full-document pass -- deterministically 2, not 1.
+    assert.equal(counter.passes, 1, `expected exactly one pass once settled, got ${counter.passes}`);
+
+    // And it must stay settled -- no perpetual retriggering off its own writes.
+    await flush(DEBOUNCE_MS * 6);
+    assert.equal(counter.passes, 1);
+  } finally {
+    teardownDom();
+  }
+});
+
 export { installDom, teardownDom, flush, captureLogs, bundleProvider, NL_DE, DEBOUNCE_MS };

--- a/src/js/common/localization.test.mjs
+++ b/src/js/common/localization.test.mjs
@@ -462,4 +462,61 @@ test("a node already showing another locale's translated value is retranslated v
   }
 });
 
+test("a settled pass does not re-translate unchanged text nodes or attributes", async () => {
+  const { dom } = installDom(`<p>Hello</p><p>Goodbye</p><button title="Hello">Hello</button>`);
+
+  try {
+    const { provider, stats } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+    msg("Hello");
+    msg("Goodbye");
+
+    await flush();
+    assert.equal(dom.window.document.querySelector("p").textContent, "Hallo");
+
+    const translateCallsAtSettle = stats.translateCalls;
+
+    // Unrelated: forces exactly one more pass, but touches no localizable
+    // node or attribute. Before the skip cache, every pass re-translated
+    // every localizable node/attribute regardless of whether anything about
+    // it had changed.
+    dom.window.document.body.appendChild(dom.window.document.createElement("span"));
+    await flush();
+
+    assert.equal(
+      stats.translateCalls,
+      translateCallsAtSettle,
+      "expected no translate() calls for nodes that have not changed"
+    );
+  } finally {
+    teardownDom();
+  }
+});
+
+test("a key registered after a node was first visited is still localized", async () => {
+  const { dom } = installDom(`<p>Other</p><p id="target">Hello</p>`);
+
+  try {
+    const { provider } = bundleProvider(NL_DE);
+    configureLocalization({ locale: "nl", provider });
+
+    // Registers a key so requestedKeys is non-empty (the pass does not bail
+    // at the empty-registry guard), and settles -- caching a NEGATIVE
+    // decision for the still-unregistered "Hello" text.
+    msg("Other");
+    await flush();
+    assert.equal(dom.window.document.getElementById("target").textContent, "Hello");
+
+    // Only now does something register "Hello". Without invalidating the
+    // skip cache on a newly registered key, this node's cached "nothing to
+    // do here" from the pass above would never be revisited.
+    msg("Hello");
+    await flush();
+
+    assert.equal(dom.window.document.getElementById("target").textContent, "Hallo");
+  } finally {
+    teardownDom();
+  }
+});
+
 export { installDom, teardownDom, flush, captureLogs, bundleProvider, NL_DE, DEBOUNCE_MS };

--- a/src/js/common/msg.js
+++ b/src/js/common/msg.js
@@ -1,9 +1,0 @@
-export {
-  msg,
-  str,
-  joinStringsAndValues,
-  configureLocalization,
-  loadLocale,
-  setLocale,
-  getLocalizationState,
-} from "./localization.js";

--- a/src/js/pds.js
+++ b/src/js/pds.js
@@ -978,7 +978,12 @@ async function start(config) {
     if (localizationConfig) {
       await __loadLocalizationRuntime();
       configureLocalization(localizationConfig);
-    } else {
+    } else if (!__getLocalizationRuntimeSync()) {
+      // With no runtime loaded this usefully resets __fallbackLocalizationState
+      // and touches no shared state. With a runtime loaded it would forward to
+      // the real configureLocalization and tear down a working provider -- and
+      // since that state is realm-wide, every copy of the runtime on the page
+      // would lose its configuration at once.
       configureLocalization(null);
     }
 


### PR DESCRIPTION
PR 2 (fix-localization-reconcile-starvation) is done — 8 staged commits on top of Fix localization shared state #31

What's in it, in commit order:

jsdom test harness — 4 characterization tests, green before any perf change
Serialize + bound reconcile passes (root cause 1) — was stacking unboundedly (6 concurrent walks from 5 spaced mutations); now capped at 5 with a warn-and-reschedule
Ignore the reconciler's own writes (root cause 2) — every settle cost one deterministic, wasted extra pass; gone
Collect roots once per pass (root cause 3a) — 3 full-tree snapshots per root down to 1; also fixed a shadow-scoped lang prune-and-reload loop it surfaced
Reverse value→key index (root cause 3c) — replaced the O(keys×locales) scan; pure refactor, no behavior change
Skip-cache for unchanged nodes/attributes (root cause 3b) — the riskiest change, with every invalidation site (new key, locale load, setLocale, lang mutation, configureLocalization reset) each backed by its own regression test
Cap the value index (root cause 4) — FIFO at 1000, indexedValueCount added to getLocalizationState()
Stop cloning the locale map per translation — an allocation source the ported patch never touched, found during design review
LOCALIZATION.md docs
Every behavioral commit was verified red-on-parent, green-on-itself, and the full 22-test suite stays green throughout. Measured against an identical 20-node-plus-shadow-root scenario: translate() calls for an unrelated DOM mutation went from 22 to 0 — that's the number the consumer's allocation profile was actually complaining about.